### PR TITLE
Lazy font family population

### DIFF
--- a/src/java.desktop/macosx/classes/sun/font/CFont.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFont.java
@@ -36,7 +36,7 @@ import java.awt.geom.Rectangle2D;
 // For some reason the JNI IsInstanceOf was not working correctly
 // so we are checking the class specifically. If we subclass this
 // we need to modify the native code in CFontWrapper.m
-public final class CFont extends PhysicalFont implements FontSubstitution {
+public final class CFont extends PhysicalFont implements FontSubstitution, FontWithDerivedItalic {
 
     /* CFontStrike doesn't call these methods so they are unimplemented.
      * They are here to meet the requirements of PhysicalFont, needed
@@ -265,5 +265,9 @@ public final class CFont extends PhysicalFont implements FontSubstitution {
         return "CFont { fullName: " + fullName +
             ",  familyName: " + familyName + ", style: " + style +
             " } aka: " + super.toString();
+    }
+
+    public Font2D createItalic() {
+      return this.createItalicVariant(true);
     }
 }

--- a/src/java.desktop/macosx/classes/sun/font/CFontManager.java
+++ b/src/java.desktop/macosx/classes/sun/font/CFontManager.java
@@ -183,37 +183,6 @@ public final class CFontManager extends SunFontManager {
         registerGenericFont(font);
     }
 
-    void registerItalicDerived() {
-        FontFamily[] famArr = FontFamily.getAllFontFamilies();
-        for (int i=0; i<famArr.length; i++) {
-            FontFamily family = famArr[i];
-
-            Font2D f2dPlain = family.getFont(Font.PLAIN);
-            if (f2dPlain != null && !(f2dPlain instanceof CFont)) continue;
-            Font2D f2dBold = family.getFont(Font.BOLD);
-            if (f2dBold != null && !(f2dBold instanceof CFont)) continue;
-            Font2D f2dItalic = family.getFont(Font.ITALIC);
-            if (f2dItalic != null && !(f2dItalic instanceof CFont)) continue;
-            Font2D f2dBoldItalic = family.getFont(Font.BOLD|Font.ITALIC);
-            if (f2dBoldItalic != null && !(f2dBoldItalic instanceof CFont)) continue;
-
-            CFont plain = (CFont)f2dPlain;
-            CFont bold = (CFont)f2dBold;
-            CFont italic = (CFont)f2dItalic;
-            CFont boldItalic = (CFont)f2dBoldItalic;
-
-            if (bold == null) bold = plain;
-            if (plain == null && bold == null) continue;
-            if (italic != null && boldItalic != null) continue;
-            if (plain != null && italic == null) {
-               registerGenericFont(plain.createItalicVariant(true), true);
-            }
-            if (bold != null && boldItalic == null) {
-               registerGenericFont(bold.createItalicVariant(true), true);
-            }
-        }
-    }
-
     Object waitForFontsToBeLoaded  = new Object();
     private boolean loadedAllFonts = false;
 
@@ -227,7 +196,6 @@ public final class CFontManager extends SunFontManager {
                     public Object run() {
                         if (!loadedAllFonts) {
                            loadNativeFonts();
-                           registerItalicDerived();
                            loadedAllFonts = true;
                         }
                         return null;

--- a/src/java.desktop/share/classes/sun/font/FontWithDerivedItalic.java
+++ b/src/java.desktop/share/classes/sun/font/FontWithDerivedItalic.java
@@ -1,0 +1,5 @@
+package sun.font;
+
+interface FontWithDerivedItalic {
+  Font2D createItalic();
+}


### PR DESCRIPTION
Avoid calling expensive native getWidth on font when creating font family, load styles only when they would be used.