### PR TITLE
Dcevm

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -954,6 +954,7 @@ void ClassFileParser::parse_interfaces(const ClassFileStream* const stream,
                                                   CHECK);
       }
 
+      // (DCEVM) pick newest
       interf = (Klass *) maybe_newest(interf);
 
       if (!interf->is_interface()) {
@@ -3749,6 +3750,7 @@ const InstanceKlass* ClassFileParser::parse_super_class(ConstantPool* const cp,
     // However, make sure it is not an array type.
     bool is_array = false;
     if (cp->tag_at(super_class_index).is_klass()) {
+      // (DCEVM) pick newest
       super_klass = InstanceKlass::cast(maybe_newest(cp->resolved_klass_at(super_class_index)));
       if (need_verify)
         is_array = super_klass->is_array_klass();
@@ -4417,7 +4419,7 @@ void ClassFileParser::set_precomputed_flags(InstanceKlass* ik) {
   if (!_has_empty_finalizer) {
     if (_has_finalizer ||
         (super != NULL && super->has_finalizer())) {
-        // FIXME - condition from previous DCEVM version, however after reload new finelize() method is not active
+        // FIXME - (DCEVM) this is condition from previous DCEVM version, however after reload a new finalize() method is not active
         if (ik->old_version() == NULL || ik->old_version()->has_finalizer()) {
           ik->set_has_finalizer();
         }

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -499,7 +499,7 @@ class ClassFileParser {
                      FieldLayoutInfo* info,
                      TRAPS);
 
-  // Enhanced class redefinition
+  // (DCEVM) Enhanced class redefinition
   inline const Klass* maybe_newest(const Klass* klass) const { return klass != NULL && _pick_newest ? klass->newest_version() : klass; }
 
  public:

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -663,6 +663,15 @@ Dictionary* ClassLoaderData::create_dictionary() {
   return new Dictionary(this, size, resizable);
 }
 
+void ClassLoaderData::exchange_holders(ClassLoaderData* cld) {
+  oop holder_oop = _holder.peek();
+  _holder.replace(cld->_holder.peek());
+  cld->_holder.replace(holder_oop);
+  WeakHandle<vm_class_loader_data> exchange = _holder;
+  _holder = cld->_holder;
+  cld->_holder = exchange;
+}
+
 // Tell the GC to keep this klass alive while iterating ClassLoaderDataGraph
 oop ClassLoaderData::holder_phantom() const {
   // A klass that was previously considered dead can be looked up in the

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1242,6 +1242,7 @@ void ClassLoaderDataGraph::dictionary_classes_do(void f(InstanceKlass*)) {
   }
 }
 
+// (DCEVM) - iterate over dict classes
 void ClassLoaderDataGraph::dictionary_classes_do(KlassClosure* klass_closure) {
   FOR_ALL_DICTIONARY(cld) {
     cld->dictionary()->classes_do(klass_closure);
@@ -1257,6 +1258,7 @@ void ClassLoaderDataGraph::dictionary_classes_do(void f(InstanceKlass*, TRAPS), 
   }
 }
 
+// (DCEVM) rollback redefined classes
 void ClassLoaderDataGraph::rollback_redefinition() {
   FOR_ALL_DICTIONARY(cld) {
     cld->dictionary()->rollback_redefinition();

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1387,12 +1387,13 @@ bool ClassLoaderDataGraph::do_unloading(bool clean_previous_versions) {
   // Klassesoto delete.
 
   // FIXME: dcevm - block asserts in MetadataOnStackMark
-  /*
-  bool walk_all_metadata = clean_previous_versions &&
-                           JvmtiExport::has_redefined_a_class() &&
-                           InstanceKlass::has_previous_versions_and_reset();
-  MetadataOnStackMark md_on_stack(walk_all_metadata);
-  */
+  bool walk_all_metadata = false;
+  if (!AllowEnhancedClassRedefinition) {
+    walk_all_metadata = clean_previous_versions &&
+                             JvmtiExport::has_redefined_a_class() &&
+                             InstanceKlass::has_previous_versions_and_reset();
+    MetadataOnStackMark md_on_stack(walk_all_metadata);
+  }
 
   // Save previous _unloading pointer for CMS which may add to unloading list before
   // purging and we don't want to rewalk the previously unloaded class loader data.
@@ -1402,12 +1403,12 @@ bool ClassLoaderDataGraph::do_unloading(bool clean_previous_versions) {
   while (data != NULL) {
     if (data->is_alive()) {
       // clean metaspace
-      /*
-      if (walk_all_metadata) {
-        data->classes_do(InstanceKlass::purge_previous_versions);
+      if (!AllowEnhancedClassRedefinition) {
+        if (walk_all_metadata) {
+          data->classes_do(InstanceKlass::purge_previous_versions);
+        }
+        data->free_deallocate_list();
       }
-      data->free_deallocate_list();
-      */
       prev = data;
       data = data->next();
       loaders_processed++;

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -292,6 +292,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   void accumulate_modified_oops()        { if (has_modified_oops()) _accumulated_modified_oops = true; }
   void clear_accumulated_modified_oops() { _accumulated_modified_oops = false; }
   bool has_accumulated_modified_oops()   { return _accumulated_modified_oops; }
+  void exchange_holders(ClassLoaderData* cld);
  private:
 
   void unload();

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -245,6 +245,8 @@ void Dictionary::classes_do(void f(InstanceKlass*)) {
   }
 }
 
+
+// (DCEVM) iterate over dict entry
 void Dictionary::classes_do(KlassClosure* closure) {
   for (int index = 0; index < table_size(); index++) {
     for (DictionaryEntry* probe = bucket(index);
@@ -342,6 +344,7 @@ DictionaryEntry* Dictionary::get_entry(int index, unsigned int hash,
   return NULL;
 }
 
+// (DCEVM) replace old_class by new class in dictionary
 bool Dictionary::update_klass(unsigned int hash, Symbol* name, ClassLoaderData* loader_data, InstanceKlass* k, InstanceKlass* old_klass) {
   // There are several entries for the same class in the dictionary: One extra entry for each parent classloader of the classloader of the class.
   bool found = false;
@@ -356,6 +359,7 @@ bool Dictionary::update_klass(unsigned int hash, Symbol* name, ClassLoaderData* 
   return found;
 }
 
+// (DCEVM) rollback redefinition
 void Dictionary::rollback_redefinition() {
   for (int index = 0; index < table_size(); index++) {
     for (DictionaryEntry* entry = bucket(index);

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -119,6 +119,7 @@ public:
 
   void rollback_redefinition();
 
+  // (DCEVM) return old class if redefining in AllowEnhancedClassRedefinition, otherwise return "k"
   static InstanceKlass* old_if_redefined(InstanceKlass* k) {
     return (k != NULL && k->is_redefining()) ? ((InstanceKlass* )k->old_version()) : k;
   }

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -4,7 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation) replace old_class by new class in dictionary.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -87,6 +87,7 @@ LoaderConstraintEntry** LoaderConstraintTable::find_loader_constraint(
   return pp;
 }
 
+// (DCEVM) update constraint entries to new classes, called from dcevm redefinition code only
 void LoaderConstraintTable::update_after_redefinition() {
   for (int index = 0; index < table_size(); index++) {
     LoaderConstraintEntry** p = bucket_addr(index);

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -876,7 +876,8 @@ Klass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
     ClassLoaderData* loader_data = k->class_loader_data();
     MutexLocker mu(SystemDictionary_lock, THREAD);
     Klass* kk = find_class(name, loader_data);
-    // FIXME: (kk == k() && !k->is_redefining()) || (k->is_redefining() && kk == k->old_version())
+    // FIXME: (DCEVM)
+    // assert(kk == k() && !k->is_redefining()) || (k->is_redefining() && kk == k->old_version())
     assert(kk == k, "should be present in dictionary");
   }
 #endif
@@ -1083,7 +1084,7 @@ InstanceKlass* SystemDictionary::resolve_from_stream(Symbol* class_name,
  InstanceKlass* k = NULL;
 
 #if INCLUDE_CDS
-  // FIXME: what to do during redefinition?
+  // FIXME: (DCEVM) what to do during redefinition?
   if (!DumpSharedSpaces) {
     k = SystemDictionaryShared::lookup_from_stream(class_name,
                                                    class_loader,
@@ -1836,7 +1837,7 @@ void SystemDictionary::add_to_hierarchy(InstanceKlass* k, TRAPS) {
   CodeCache::flush_dependents_on(k);
 }
 
-// Enhanced class redefinition
+// (DCEVM) - remove from klass hierarchy
 void SystemDictionary::remove_from_hierarchy(InstanceKlass* k) {
     assert(k != NULL, "just checking");
 
@@ -1844,6 +1845,7 @@ void SystemDictionary::remove_from_hierarchy(InstanceKlass* k) {
   k->remove_from_sibling_list();
 }
 
+// (DCEVM) 
 void SystemDictionary::update_constraints_after_redefinition() {
   constraints()->update_after_redefinition();
 }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -971,12 +971,16 @@ InstanceKlass* SystemDictionary::parse_stream(Symbol* class_name,
                                               Handle protection_domain,
                                               ClassFileStream* st,
                                               const InstanceKlass* host_klass,
+                                              InstanceKlass* old_klass,
                                               GrowableArray<Handle>* cp_patches,
                                               TRAPS) {
 
   EventClassLoad class_load_start_event;
 
   ClassLoaderData* loader_data;
+
+  bool is_redefining = (old_klass != NULL);
+
   if (host_klass != NULL) {
     // Create a new CLD for anonymous class, that uses the same class loader
     // as the host_klass
@@ -1000,8 +1004,12 @@ InstanceKlass* SystemDictionary::parse_stream(Symbol* class_name,
                                                       protection_domain,
                                                       host_klass,
                                                       cp_patches,
-                                                      false, // pick_newest
+                                                      is_redefining, // pick_newest
                                                       CHECK_NULL);
+  if (is_redefining && k != NULL) {
+    k->set_redefining(true);
+    k->set_old_version(old_klass);
+  }
 
   if (host_klass != NULL && k != NULL) {
     // Anonymous classes must update ClassLoaderData holder (was host_klass loader)
@@ -1845,7 +1853,7 @@ void SystemDictionary::remove_from_hierarchy(InstanceKlass* k) {
   k->remove_from_sibling_list();
 }
 
-// (DCEVM) 
+// (DCEVM)
 void SystemDictionary::update_constraints_after_redefinition() {
   constraints()->update_after_redefinition();
 }

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -301,6 +301,7 @@ public:
                         protection_domain,
                         st,
                         NULL, // host klass
+                        NULL, // old class
                         NULL, // cp_patches
                         THREAD);
   }
@@ -309,6 +310,7 @@ public:
                                      Handle protection_domain,
                                      ClassFileStream* st,
                                      const InstanceKlass* host_klass,
+                                     InstanceKlass* old_klass,
                                      GrowableArray<Handle>* cp_patches,
                                      TRAPS);
 

--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -84,7 +84,7 @@ Bytecodes::Code Bytecodes::code_at(Method* method, int bci) {
 Bytecodes::Code Bytecodes::non_breakpoint_code_at(const Method* method, address bcp) {
   assert(method != NULL, "must have the method for breakpoint conversion");
   assert(method->contains(bcp), "must be valid bcp in method");
-  return method->orig_bytecode_at(method->bci_from(bcp));
+  return method->orig_bytecode_at(method->bci_from(bcp), false);
 }
 
 int Bytecodes::special_length_at(Bytecodes::Code code, address bcp, address end) {

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -834,7 +834,7 @@ IRT_END
 // Invokes
 
 IRT_ENTRY(Bytecodes::Code, InterpreterRuntime::get_original_bytecode_at(JavaThread* thread, Method* method, address bcp))
-  return method->orig_bytecode_at(method->bci_from(bcp));
+  return method->orig_bytecode_at(method->bci_from(bcp), false);
 IRT_END
 
 IRT_ENTRY(void, InterpreterRuntime::set_original_bytecode_at(JavaThread* thread, Method* method, address bcp, Bytecodes::Code new_code))

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1384,6 +1384,7 @@ void LinkResolver::runtime_resolve_virtual_method(CallInfo& result,
       assert(resolved_method->can_be_statically_bound(), "cannot override this method");
       selected_method = resolved_method;
     } else {
+      // TODO: (DCEVM) explain
       assert(recv_klass->is_subtype_of(resolved_method->method_holder()), "receiver and resolved method holder are inconsistent");
       selected_method = methodHandle(THREAD, recv_klass->method_at_vtable(vtable_index));
     }

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -176,7 +176,7 @@ void Universe::basic_type_classes_do(void f(Klass*)) {
   f(doubleArrayKlassObj());
 }
 
-// FIXME: This method should iterate all pointers that are not within heap objects.
+// FIXME: (DCEVM) This method should iterate all pointers that are not within heap objects.
 void Universe::root_oops_do(OopClosure *oopClosure) {
 
   class AlwaysTrueClosure: public BoolObjectClosure {
@@ -203,7 +203,7 @@ void Universe::root_oops_do(OopClosure *oopClosure) {
   CodeBlobToOopClosure blobClosure(oopClosure, CodeBlobToOopClosure::FixRelocations);
   CodeCache::blobs_do(&blobClosure);
   StringTable::oops_do(oopClosure);
-  
+
   // (DCEVM) TODO: Check if this is correct?
   //CodeCache::scavenge_root_nmethods_oops_do(oopClosure);
   //Management::oops_do(oopClosure);

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -436,8 +436,7 @@ void ConstantPoolCacheEntry::set_method_handle_common(const constantPoolHandle& 
   if (has_appendix) {
     const int appendix_index = f2_as_index() + _indy_resolved_references_appendix_offset;
     assert(appendix_index >= 0 && appendix_index < resolved_references->length(), "oob");
-    // FIXME (DCEVM) relaxing for now...
-    //assert(resolved_references->obj_at(appendix_index) == NULL, "init just once");
+    assert(AllowEnhancedClassRedefinition || resolved_references->obj_at(appendix_index) == NULL, "init just once");
     resolved_references->obj_at_put(appendix_index, appendix());
   }
 
@@ -445,8 +444,7 @@ void ConstantPoolCacheEntry::set_method_handle_common(const constantPoolHandle& 
   if (has_method_type) {
     const int method_type_index = f2_as_index() + _indy_resolved_references_method_type_offset;
     assert(method_type_index >= 0 && method_type_index < resolved_references->length(), "oob");
-    // FIXME (DCEVM) relaxing for now...
-    //assert(resolved_references->obj_at(method_type_index) == NULL, "init just once");
+    assert(AllowEnhancedClassRedefinition || resolved_references->obj_at(method_type_index) == NULL, "init just once");
     resolved_references->obj_at_put(method_type_index, method_type());
   }
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -788,10 +788,10 @@ bool InstanceKlass::link_class_impl(bool throw_verifyerror, TRAPS) {
 
     if (!is_linked()) {
       if (!is_rewritten()) {
-        // In cases, if class A is being redefined and class B->A (B is extended from A) and B is host class of anonymous class C
+        // (DCEVM): If class A is being redefined and class B->A (B is extended from A) and B is host class of anonymous class C
         // then second redefinition fails with cannot cast klass exception. So we currently turn off bytecode verification
         // on redefinition.
-        if (!newest_version()->is_redefining()) {
+        if (!AllowEnhancedClassRedefinition || !newest_version()->is_redefining()) {
           bool verify_ok = verify_code(throw_verifyerror, THREAD);
           if (!verify_ok) {
             return false;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1139,6 +1139,7 @@ void InstanceKlass::init_implementor() {
   }
 }
 
+// (DCEVM) - init_implementor() for dcevm
 void InstanceKlass::init_implementor_from_redefine() {
   assert(is_interface(), "not interface");
   Klass** addr = adr_implementor();
@@ -1209,6 +1210,8 @@ bool InstanceKlass::implements_interface(Klass* k) const {
   return false;
 }
 
+
+// (DCEVM)
 bool InstanceKlass::implements_interface_any_version(Klass* k) const {
   k = k->newest_version();
   if (this->newest_version() == k) return true;
@@ -1491,10 +1494,8 @@ void InstanceKlass::methods_do(void f(Method* method)) {
   }
 }
 
-/**
-  Update information contains mapping of fields from old class to the new class.
-  Info is stored on HEAP, you need to call clear_update_information to free the space.
-*/
+//  (DCEVM) Update information contains mapping of fields from old class to the new class.
+//  Info is stored on HEAP, you need to call clear_update_information to free the space.
 void InstanceKlass::store_update_information(GrowableArray<int> &values) {
   int *arr = NEW_C_HEAP_ARRAY(int, values.length(), mtClass);
   for (int i = 0; i < values.length(); i++) {
@@ -2162,6 +2163,7 @@ void InstanceKlass::add_dependent_nmethod(nmethod* nm) {
   dependencies().add_dependent_nmethod(nm);
 }
 
+// DCEVM - update jmethod ids
 bool InstanceKlass::update_jmethod_id(Method* method, jmethodID newMethodID) {
   size_t idnum = (size_t)method->method_idnum();
   jmethodID* jmeths = methods_jmethod_ids_acquire();
@@ -2177,7 +2179,7 @@ bool InstanceKlass::update_jmethod_id(Method* method, jmethodID newMethodID) {
 
 void InstanceKlass::remove_dependent_nmethod(nmethod* nm, bool delete_immediately) {
   dependencies().remove_dependent_nmethod(nm, delete_immediately);
-  // (DCEVM) Hack as dependencies get wrong version of Klass*
+  // FIXME: (DCEVM) Hack as dependencies get wrong version of Klass*
 //  if (this->old_version() != NULL) {
 //    InstanceKlass::cast(this->old_version())->remove_dependent_nmethod(nm, true);
 //    return;
@@ -3594,6 +3596,7 @@ void InstanceKlass::verify_on(outputStream* st) {
     }
 
     guarantee(sib->is_klass(), "should be klass");
+    // TODO: (DCEVM) explain
     guarantee(sib->super() == super || super->newest_version() == SystemDictionary::Object_klass(), "siblings should have same superklass");
   }
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1747,14 +1747,14 @@ bool CompressedLineNumberReadStream::read_pair() {
 
 #if INCLUDE_JVMTI
 
-Bytecodes::Code Method::orig_bytecode_at(int bci) const {
+Bytecodes::Code Method::orig_bytecode_at(int bci, bool no_fatal) const {
   BreakpointInfo* bp = method_holder()->breakpoints();
   for (; bp != NULL; bp = bp->next()) {
     if (bp->match(this, bci)) {
       return bp->orig_bytecode();
     }
   }
-  {
+  if (!no_fatal) {
     ResourceMark rm;
     fatal("no original bytecode found in %s at bci %d", name_and_sig_as_C_string(), bci);
   }
@@ -1900,7 +1900,7 @@ BreakpointInfo::BreakpointInfo(Method* m, int bci) {
   _signature_index = m->signature_index();
   _orig_bytecode = (Bytecodes::Code) *m->bcp_from(_bci);
   if (_orig_bytecode == Bytecodes::_breakpoint)
-    _orig_bytecode = m->orig_bytecode_at(_bci);
+    _orig_bytecode = m->orig_bytecode_at(_bci, false);
   _next = NULL;
 }
 
@@ -1909,7 +1909,7 @@ void BreakpointInfo::set(Method* method) {
   {
     Bytecodes::Code code = (Bytecodes::Code) *method->bcp_from(_bci);
     if (code == Bytecodes::_breakpoint)
-      code = method->orig_bytecode_at(_bci);
+      code = method->orig_bytecode_at(_bci, false);
     assert(orig_bytecode() == code, "original bytecode must be the same");
   }
 #endif

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -230,7 +230,7 @@ class Method : public Metadata {
 
   // JVMTI breakpoints
 #if !INCLUDE_JVMTI
-  Bytecodes::Code orig_bytecode_at(int bci) const {
+  Bytecodes::Code orig_bytecode_at(int bci, bool no_fatal) const {
     ShouldNotReachHere();
     return Bytecodes::_shouldnotreachhere;
   }
@@ -239,7 +239,7 @@ class Method : public Metadata {
   };
   u2   number_of_breakpoints() const {return 0;}
 #else // !INCLUDE_JVMTI
-  Bytecodes::Code orig_bytecode_at(int bci) const;
+  Bytecodes::Code orig_bytecode_at(int bci, bool no_fatal) const;
   void set_orig_bytecode_at(int bci, Bytecodes::Code code);
   void set_breakpoint(int bci);
   void clear_breakpoint(int bci);

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -67,21 +67,19 @@ int         VM_EnhancedRedefineClasses::_deleted_methods_length  = 0;
 int         VM_EnhancedRedefineClasses::_added_methods_length    = 0;
 Klass*      VM_EnhancedRedefineClasses::_the_class_oop = NULL;
 
-/**
- * Create new instance of enhanced class redefiner.
- *
- * This class implements VM_GC_Operation - the usual usage should be:
- *     VM_EnhancedRedefineClasses op(class_count, class_definitions, jvmti_class_load_kind_redefine);
- *     VMThread::execute(&op);
- * Which
- *
- * @param class_count size of class_defs
- * @param class_defs class definition - either new class or redefined class
- *               note that this is not the final array of classes to be redefined
- *               we need to scan for all affected classes (e.g. subclasses) and
- *               caculcate redefinition for them as well.
- * @param class_load_kind always jvmti_class_load_kind_redefine
- */
+//
+// Create new instance of enhanced class redefiner.
+//
+// This class implements VM_GC_Operation - the usual usage should be:
+//     VM_EnhancedRedefineClasses op(class_count, class_definitions, jvmti_class_load_kind_redefine);
+//     VMThread::execute(&op);
+// Which
+//  - class_count size of class_defs
+//  - class_defs class definition - either new class or redefined class
+//               note that this is not the final array of classes to be redefined
+//               we need to scan for all affected classes (e.g. subclasses) and
+//               caculcate redefinition for them as well.
+// @param class_load_kind always jvmti_class_load_kind_redefine
 VM_EnhancedRedefineClasses::VM_EnhancedRedefineClasses(jint class_count, const jvmtiClassDefinition *class_defs, JvmtiClassLoadKind class_load_kind) :
         VM_GC_Operation(Universe::heap()->total_collections(), GCCause::_heap_inspection, Universe::heap()->total_full_collections(), true) {
   _affected_klasses = NULL;
@@ -97,12 +95,10 @@ static inline InstanceKlass* get_ik(jclass def) {
   return InstanceKlass::cast(java_lang_Class::as_Klass(mirror));
 }
 
-/**
- * Start the redefinition:
- * - Load new class definitions - @see load_new_class_versions
- * - Start mark&sweep GC.
- * @return true if success, otherwise all chnages are rollbacked.
- */
+// Start the redefinition:
+// - Load new class definitions - @see load_new_class_versions
+// - Start mark&sweep GC.
+// - true if success, otherwise all chnages are rollbacked.
 bool VM_EnhancedRedefineClasses::doit_prologue() {
 
   if (_class_count == 0) {
@@ -175,9 +171,7 @@ bool VM_EnhancedRedefineClasses::doit_prologue() {
   return true;
 }
 
-/**
- * Closer for static fields - copy value from old class to the new class.
- */
+// Closer for static fields - copy value from old class to the new class.
 class FieldCopier : public FieldClosure {
   public:
   void do_field(fieldDescriptor* fd) {
@@ -236,9 +230,7 @@ struct StoreNoBarrier {
   template <class T> static void oop_store(T* p) { RawAccess<>::oop_store(p, oop(NULL)); }
 };
 
-/**
-  Closure to scan all heap objects and update method handles
-*/
+// Closure to scan all heap objects and update method handles
 template <class S>
 class ChangePointersOopClosure : public BasicOopIterateClosure {
   // import java_lang_invoke_MemberName.*
@@ -246,7 +238,6 @@ class ChangePointersOopClosure : public BasicOopIterateClosure {
     REFERENCE_KIND_SHIFT = java_lang_invoke_MemberName::MN_REFERENCE_KIND_SHIFT,
     REFERENCE_KIND_MASK  = java_lang_invoke_MemberName::MN_REFERENCE_KIND_MASK,
   };
-
 
   bool update_member_name(oop obj) {
     int flags    =       java_lang_invoke_MemberName::flags(obj);
@@ -382,14 +373,12 @@ class ChangePointersOopClosure : public BasicOopIterateClosure {
   }
 };
 
-/**
- * Closure to scan all objects on heap for objects of changed classes
- *   - if the fields are compatible, only update class definition reference
- *   - otherwise if the new object size is smaller then old size, reshufle
- *          the fields and fill the gap with "dead_space"
- *   - otherwise set the _needs_instance_update flag, we need to do full GC
- *          and reshuffle object positions durring mark&sweep
- */
+// Closure to scan all objects on heap for objects of changed classes
+//  - if the fields are compatible, only update class definition reference
+//  - otherwise if the new object size is smaller then old size, reshufle
+//         the fields and fill the gap with "dead_space"
+//  - otherwise set the _needs_instance_update flag, we need to do full GC
+//         and reshuffle object positions durring mark&sweep
 class ChangePointersObjectClosure : public ObjectClosure {
   private:
 
@@ -451,19 +440,16 @@ public:
 };
 
 
-/**
-  Main transformation method - runs in VM thread.
-
-  - UseSharedSpaces - TODO what does it mean?
-  - for each sratch class call redefine_single_class
-  - clear code cache (flush_dependent_code)
-  - iterate the heap and update object defintions, check it old/new class fields
-       are compatible. If new class size is smaller then old, it can be solved directly here.
-  - iterate the heap and update method handles to new version
-  - Swap marks to have same hashcodes
-  - copy static fields
-  - notify JVM of the modification
-*/
+// Main transformation method - runs in VM thread.
+//  - UseSharedSpaces - TODO what does it mean?
+//  - for each sratch class call redefine_single_class
+//  - clear code cache (flush_dependent_code)
+//  - iterate the heap and update object defintions, check it old/new class fields
+//       are compatible. If new class size is smaller then old, it can be solved directly here.
+//  - iterate the heap and update method handles to new version
+//  - Swap marks to have same hashcodes
+//  - copy static fields
+//  - notify JVM of the modification
 void VM_EnhancedRedefineClasses::doit() {
   Thread *thread = Thread::current();
 
@@ -634,11 +620,9 @@ void VM_EnhancedRedefineClasses::doit() {
 
 }
 
-/**
- * Cleanup - runs in JVM thread
- *  - free used memory
- *  - end GC
- */
+// Cleanup - runs in JVM thread
+//  - free used memory
+//  - end GC
 void VM_EnhancedRedefineClasses::doit_epilogue() {
   VM_GC_Operation::doit_epilogue();
 
@@ -670,11 +654,9 @@ void VM_EnhancedRedefineClasses::doit_epilogue() {
   }
 }
 
-/**
- * Exclude java primitives and arrays from redefinition
- * @param klass_mirror  pointer to the klass
- * @return true if is modifiable
- */
+// Exclude java primitives and arrays from redefinition
+//  - klass_mirror  pointer to the klass
+//  - true if is modifiable
 bool VM_EnhancedRedefineClasses::is_modifiable_class(oop klass_mirror) {
   // classes for primitives cannot be redefined
   if (java_lang_Class::is_primitive(klass_mirror)) {
@@ -693,17 +675,12 @@ bool VM_EnhancedRedefineClasses::is_modifiable_class(oop klass_mirror) {
   return true;
 }
 
-/**
-  Load and link new classes (either redefined or affected by redefinition - subclass, ...)
-
-  - find sorted affected classes
-  - resolve new class
-  - calculate redefine flags (field change, method change, supertype change, ...)
-  - calculate modified fields and mapping to old fields
-  - link new classes
-
-  The result is sotred in _affected_klasses(old definitions) and _new_classes(new definitions) arrays.
-*/
+// Load and link new classes (either redefined or affected by redefinition - subclass, ...)
+//  - find sorted affected classes
+//  - resolve new class
+//  - calculate redefine flags (field change, method change, supertype change, ...)
+//  - calculate modified fields and mapping to old fields
+//  - link new classes
 jvmtiError VM_EnhancedRedefineClasses::load_new_class_versions(TRAPS) {
 
   _affected_klasses = new (ResourceObj::C_HEAP, mtInternal) GrowableArray<Klass*>(_class_count, true);
@@ -898,9 +875,7 @@ jvmtiError VM_EnhancedRedefineClasses::load_new_class_versions(TRAPS) {
   return JVMTI_ERROR_NONE;
 }
 
-/**
-  Calculated the difference between new and old class  (field change, method change, supertype change, ...).
-*/
+ // Calculated the difference between new and old class  (field change, method change, supertype change, ...).
 int VM_EnhancedRedefineClasses::calculate_redefinition_flags(InstanceKlass* new_class) {
   int result = Klass::NoRedefinition;
   log_info(redefine, class, load)("Comparing different class versions of class %s",new_class->name()->as_C_string());
@@ -1183,14 +1158,11 @@ int VM_EnhancedRedefineClasses::calculate_redefinition_flags(InstanceKlass* new_
 }
 
 
-/**
-  Searches for the class bytecode of the given class and returns it as a byte array.
-
-  @param the_class definition of a class, either existing class or new_class
-  @param class_bytes - if the class is redefined, it contains new class definition, otherwise just original class bytecode.
-  @param class_byte_count - size of class_bytes
-  @param not_changed - new_class not available or same as current class
-*/
+// Searches for the class bytecode of the given class and returns it as a byte array.
+//  - the_class definition of a class, either existing class or new_class
+//  - class_bytes - if the class is redefined, it contains new class definition, otherwise just original class bytecode.
+//  - class_byte_count - size of class_bytes
+//  - not_changed - new_class not available or same as current class
 jvmtiError VM_EnhancedRedefineClasses::find_class_bytes(InstanceKlass* the_class, const unsigned char **class_bytes, jint *class_byte_count, jboolean *not_changed) {
 
   *not_changed = false;
@@ -1233,11 +1205,9 @@ jvmtiError VM_EnhancedRedefineClasses::find_class_bytes(InstanceKlass* the_class
   return JVMTI_ERROR_NONE;
 }
 
-/**
-  Calculate difference between non static fields of old and new class and store the info into new class:
-     instanceKlass->store_update_information
-     instanceKlass->copy_backwards
-*/
+// Calculate difference between non static fields of old and new class and store the info into new class:
+//     instanceKlass->store_update_information
+//     instanceKlass->copy_backwards
 void VM_EnhancedRedefineClasses::calculate_instance_update_information(Klass* new_version) {
 
   class CalculateFieldUpdates : public FieldClosure {
@@ -1348,9 +1318,7 @@ void VM_EnhancedRedefineClasses::calculate_instance_update_information(Klass* ne
   }
 }
 
-/**
-  Rollback all changes - clear new classes from the system dictionary, return old classes to directory, free memory.
-*/
+// Rollback all changes - clear new classes from the system dictionary, return old classes to directory, free memory.
 void VM_EnhancedRedefineClasses::rollback() {
   log_info(redefine, class, load)("Rolling back redefinition, result=%d", _res);
   ClassLoaderDataGraph::rollback_redefinition();
@@ -1547,9 +1515,7 @@ void VM_EnhancedRedefineClasses::update_jmethod_ids() {
   }
 }
 
-/**
-  Set method as obsolete / old / deleted.
-*/
+// Set method as obsolete / old / deleted.
 void VM_EnhancedRedefineClasses::check_methods_and_mark_as_obsolete() {
   for (int j = 0; j < _matching_methods_length; ++j/*, ++old_index*/) {
     Method* old_method = _matching_old_methods[j];
@@ -1771,12 +1737,9 @@ void VM_EnhancedRedefineClasses::flush_dependent_code(InstanceKlass* k_h, TRAPS)
   }
 }
 
-/**
-  Compare _old_methods and _new_methods arrays and store the result into
-	_matching_old_methods, _matching_new_methods, _added_methods, _deleted_methods
-
-  Setup _old_methods and _new_methods before the call - it should be called for one class only!
-*/
+//  Compare _old_methods and _new_methods arrays and store the result into
+//  _matching_old_methods, _matching_new_methods, _added_methods, _deleted_methods
+//  Setup _old_methods and _new_methods before the call - it should be called for one class only!
 void VM_EnhancedRedefineClasses::compute_added_deleted_matching_methods() {
   Method* old_method;
   Method* new_method;
@@ -1900,7 +1863,6 @@ void VM_EnhancedRedefineClasses::redefine_single_class(InstanceKlass* new_class_
   }
   */
 
-
   {
     ResourceMark rm(THREAD);
     // increment the classRedefinedCount field in the_class and in any
@@ -1940,9 +1902,7 @@ void VM_EnhancedRedefineClasses::check_class(InstanceKlass* ik, TRAPS) {
   }
 }
 
-/**
- * Logging of all methods (old, new, changed, ...)
- */
+// Logging of all methods (old, new, changed, ...)
 void VM_EnhancedRedefineClasses::dump_methods() {
   int j;
   log_trace(redefine, class, dump)("_old_methods --");
@@ -2002,9 +1962,7 @@ void VM_EnhancedRedefineClasses::dump_methods() {
   }
 }
 
-/**
-  Helper class to traverse all loaded classes and figure out if the class is affected by redefinition.
-*/
+// Helper class to traverse all loaded classes and figure out if the class is affected by redefinition.
 class AffectedKlassClosure : public KlassClosure {
  private:
    GrowableArray<Klass*>* _affected_klasses;
@@ -2052,10 +2010,8 @@ class AffectedKlassClosure : public KlassClosure {
   }
 };
 
-/**
-  Find all affected classes by current redefinition (either because of redefine, class hierarchy or interface change).
-  Affected classes are stored in _affected_klasses and parent classes always precedes child class.
-*/
+// Find all affected classes by current redefinition (either because of redefine, class hierarchy or interface change).
+// Affected classes are stored in _affected_klasses and parent classes always precedes child class.
 jvmtiError VM_EnhancedRedefineClasses::find_sorted_affected_classes(TRAPS) {
   for (int i = 0; i < _class_count; i++) {
     InstanceKlass* klass_handle = get_ik(_class_defs[i].klass);
@@ -2086,9 +2042,7 @@ jvmtiError VM_EnhancedRedefineClasses::find_sorted_affected_classes(TRAPS) {
   return JVMTI_ERROR_NONE;
 }
 
-/**
-  Pairs of class dependencies (for topological sort)
-*/
+// Pairs of class dependencies (for topological sort)
 struct KlassPair {
   const Klass* _left;
   const Klass* _right;
@@ -2101,14 +2055,11 @@ static bool match_second(void* value, KlassPair elem) {
   return elem._right == value;
 }
 
-/**
- For each class to be redefined parse the bytecode and figure out the superclass and all interfaces.
- First newly introduced classes (_class_defs) are scanned and then affected classed (_affected_klasses).
- Affected flag is cleared (clear_redefinition_flag(Klass::MarkedAsAffected))
- For each dependency create a KlassPair instance. Finnaly, affected classes (_affected_klasses) are sorted according to pairs.
-
- TODO - the class file is potentionally parsed multiple times - introduce a cache?
-*/
+// For each class to be redefined parse the bytecode and figure out the superclass and all interfaces.
+// First newly introduced classes (_class_defs) are scanned and then affected classed (_affected_klasses).
+// Affected flag is cleared (clear_redefinition_flag(Klass::MarkedAsAffected))
+// For each dependency create a KlassPair instance. Finnaly, affected classes (_affected_klasses) are sorted according to pairs.
+// TODO - the class file is potentionally parsed multiple times - introduce a cache?
 jvmtiError VM_EnhancedRedefineClasses::do_topological_class_sorting(TRAPS) {
   ResourceMark mark(THREAD);
 

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -467,6 +467,7 @@ public:
 void VM_EnhancedRedefineClasses::doit() {
   Thread *thread = Thread::current();
 
+#if INCLUDE_CDS
   if (UseSharedSpaces) {
     // Sharing is enabled so we remap the shared readonly space to
     // shared readwrite, private just in case we need to redefine
@@ -478,6 +479,7 @@ void VM_EnhancedRedefineClasses::doit() {
       return;
     }
   }
+#endif
 
   // Mark methods seen on stack and everywhere else so old methods are not
   // cleaned up if they're on the stack.

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -1389,14 +1389,16 @@ void VM_EnhancedRedefineClasses::unpatch_bytecode(Method* method) {
 
     if (code == Bytecodes::_breakpoint) {
       int bci = method->bci_from(bcp);
-      code = method->orig_bytecode_at(bci);
-      java_code = Bytecodes::java_code(code);
-      if (code != java_code &&
-           (java_code == Bytecodes::_getfield ||
-            java_code == Bytecodes::_putfield ||
-            java_code == Bytecodes::_aload_0)) {
-        // Let breakpoint table handling unpatch bytecode
-        method->set_orig_bytecode_at(bci, java_code);
+      code = method->orig_bytecode_at(bci, true);
+      if (code != Bytecodes::_shouldnotreachhere) {
+        java_code = Bytecodes::java_code(code);
+        if (code != java_code &&
+             (java_code == Bytecodes::_getfield ||
+              java_code == Bytecodes::_putfield ||
+              java_code == Bytecodes::_aload_0)) {
+          // Let breakpoint table handling unpatch bytecode
+          method->set_orig_bytecode_at(bci, java_code);
+        }
       }
     } else {
       java_code = Bytecodes::java_code(code);

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -253,7 +253,7 @@ class ChangePointersOopClosure : public BasicOopIterateClosure {
           // Note: we might set NULL at this point, which should force AbstractMethodError at runtime
           Thread *thread = Thread::current();
           CallInfo info(new_method, newest, thread);
-          Handle objHandle(thread, obj);  // TODO : review thread
+          Handle objHandle(thread, obj);
           MethodHandles::init_method_MemberName(objHandle, info);
         } else {
           java_lang_invoke_MemberName::set_method(obj, NULL);
@@ -280,7 +280,7 @@ class ChangePointersOopClosure : public BasicOopIterateClosure {
           InstanceKlass* ik_new = InstanceKlass::cast(k->newest_version());
           fieldDescriptor fd_new;
           if (ik_new->find_local_field(fd.name(), fd.signature(), &fd_new)) {
-            Handle objHandle(Thread::current(), obj);  // TODO : review thread
+            Handle objHandle(Thread::current(), obj);
             MethodHandles::init_field_MemberName(objHandle, fd_new, MethodHandles::ref_kind_is_setter(ref_kind));
           } else {
             // Matching field is not found in new version, not much we can do here.
@@ -441,10 +441,9 @@ public:
 
 
 // Main transformation method - runs in VM thread.
-//  - UseSharedSpaces - TODO what does it mean?
-//  - for each sratch class call redefine_single_class
+//  - for each scratch class call redefine_single_class
 //  - clear code cache (flush_dependent_code)
-//  - iterate the heap and update object defintions, check it old/new class fields
+//  - iterate the heap and update object definitions, check it old/new class fields
 //       are compatible. If new class size is smaller then old, it can be solved directly here.
 //  - iterate the heap and update method handles to new version
 //  - Swap marks to have same hashcodes

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -578,14 +578,14 @@ void VM_EnhancedRedefineClasses::doit() {
     }
   }
 
-//  if (objectClosure.needs_instance_update()) {
+  if (objectClosure.needs_instance_update()) {
     // Do a full garbage collection to update the instance sizes accordingly
     Universe::set_redefining_gc_run(true);
     notify_gc_begin(true);
     Universe::heap()->collect_as_vm_thread(GCCause::_heap_inspection);
     notify_gc_end();
     Universe::set_redefining_gc_run(false);
-//  }
+  }
 
   // Unmark Klass*s as "redefining"
   for (int i = 0; i < _new_classes->length(); i++) {

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -506,7 +506,7 @@ void VM_EnhancedRedefineClasses::doit() {
   // JSR-292 support
   if (_any_class_has_resolved_methods) {
     bool trace_name_printed = false;
-    ResolvedMethodTable::adjust_method_entries(&trace_name_printed);
+    ResolvedMethodTable::adjust_method_entries_dcevm(&trace_name_printed);
   }
 
   ChangePointersOopClosure<StoreNoBarrier> oopClosureNoBarrier;

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
@@ -119,6 +119,7 @@ class VM_EnhancedRedefineClasses: public VM_GC_Operation {
   void rollback();
   static void mark_as_scavengable(nmethod* nm);
   static void unpatch_bytecode(Method* method);
+  static void fix_invoke_method(Method* method);
 
   // Figure out which new methods match old methods in name and signature,
   // which methods have been added, and which are no longer present

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
@@ -16,6 +16,8 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
+ *
+ *
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
@@ -30,7 +32,6 @@
 #include "memory/resourceArea.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "oops/objArrayOop.hpp"
-#include "runtime/vmOperations.hpp"
 #include "gc/shared/vmGCOperations.hpp"
 #include "../../../java.base/unix/native/include/jni_md.h"
 

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
@@ -35,17 +35,16 @@
 #include "gc/shared/vmGCOperations.hpp"
 #include "../../../java.base/unix/native/include/jni_md.h"
 
-/**
- * Enhanced class redefiner.
- *
- * This class implements VM_GC_Operation - the usual usage should be:
- *     VM_EnhancedRedefineClasses op(class_count, class_definitions, jvmti_class_load_kind_redefine);
- *     VMThread::execute(&op);
- * Which in turn runs:
- *   - doit_prologue() - calculate all affected classes (add subclasses etc) and load new class versions
- *   - doit() - main redefition, adjust existing objects on the heap, clear caches
- *   - doit_epilogue() - cleanup
-*/
+//
+// Enhanced class redefiner.
+//
+// This class implements VM_GC_Operation - the usual usage should be:
+//     VM_EnhancedRedefineClasses op(class_count, class_definitions, jvmti_class_load_kind_redefine);
+//     VMThread::execute(&op);
+// Which in turn runs:
+//   - doit_prologue() - calculate all affected classes (add subclasses etc) and load new class versions
+//   - doit() - main redefition, adjust existing objects on the heap, clear caches
+//   - doit_epilogue() - cleanup
 class VM_EnhancedRedefineClasses: public VM_GC_Operation {
  private:
   // These static fields are needed by ClassLoaderDataGraph::classes_do()
@@ -93,17 +92,15 @@ class VM_EnhancedRedefineClasses: public VM_GC_Operation {
 
   // These routines are roughly in call order unless otherwise noted.
 
-  /**
-    Load and link new classes (either redefined or affected by redefinition - subclass, ...)
-
-    - find sorted affected classes
-    - resolve new class
-    - calculate redefine flags (field change, method change, supertype change, ...)
-    - calculate modified fields and mapping to old fields
-    - link new classes
-
-    The result is sotred in _affected_klasses(old definitions) and _new_classes(new definitions) arrays.
-  */
+  // Load and link new classes (either redefined or affected by redefinition - subclass, ...)
+  //
+  // - find sorted affected classes
+  // - resolve new class
+  // - calculate redefine flags (field change, method change, supertype change, ...)
+  // - calculate modified fields and mapping to old fields
+  // - link new classes
+  //
+  // The result is sotred in _affected_klasses(old definitions) and _new_classes(new definitions) arrays.
   jvmtiError load_new_class_versions(TRAPS);
 
   // Searches for all affected classes and performs a sorting such tha

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -294,8 +294,10 @@ void JvmtiBreakpoint::each_method_version_do(method_action meth_act) {
   Symbol* m_signature = _method->signature();
 
   // (DCEVM) Go through old versions of method
-  for (Method* m = _method->old_version(); m != NULL; m = m->old_version()) {
-    (m->*meth_act)(_bci);
+  if (AllowEnhancedClassRedefinition) {
+    for (Method* m = _method->old_version(); m != NULL; m = m->old_version()) {
+      (m->*meth_act)(_bci);
+    }
   }
 
   // search previous versions if they exist

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -197,8 +197,52 @@ void ResolvedMethodTable::print() {
 #endif // PRODUCT
 
 #if INCLUDE_JVMTI
-// It is called at safepoint only for RedefineClasses
+
 void ResolvedMethodTable::adjust_method_entries(bool * trace_name_printed) {
+  assert(SafepointSynchronize::is_at_safepoint(), "only called at safepoint");
+  // For each entry in RMT, change to new method
+  for (int i = 0; i < _the_table->table_size(); ++i) {
+    for (ResolvedMethodEntry* entry = _the_table->bucket(i);
+         entry != NULL;
+         entry = entry->next()) {
+
+      oop mem_name = entry->object_no_keepalive();
+      // except ones removed
+      if (mem_name == NULL) {
+        continue;
+      }
+      Method* old_method = (Method*)java_lang_invoke_ResolvedMethodName::vmtarget(mem_name);
+
+      if (old_method->is_old()) {
+
+        Method* new_method;
+        if (old_method->is_deleted()) {
+          new_method = Universe::throw_no_such_method_error();
+        } else {
+          InstanceKlass* holder = old_method->method_holder();
+          new_method = holder->method_with_idnum(old_method->orig_method_idnum());
+          assert(holder == new_method->method_holder(), "call after swapping redefined guts");
+          assert(new_method != NULL, "method_with_idnum() should not be NULL");
+          assert(old_method != new_method, "sanity check");
+        }
+
+        java_lang_invoke_ResolvedMethodName::set_vmtarget(mem_name, new_method);
+
+        ResourceMark rm;
+        if (!(*trace_name_printed)) {
+          log_info(redefine, class, update)("adjust: name=%s", old_method->method_holder()->external_name());
+           *trace_name_printed = true;
+        }
+        log_debug(redefine, class, update, constantpool)
+          ("ResolvedMethod method update: %s(%s)",
+           new_method->name()->as_C_string(), new_method->signature()->as_C_string());
+      }
+    }
+  }
+}
+
+// (DCEVM) It is called at safepoint only for RedefineClasses
+void ResolvedMethodTable::adjust_method_entries_dcevm(bool * trace_name_printed) {
   assert(SafepointSynchronize::is_at_safepoint(), "only called at safepoint");
   // For each entry in RMT, change to new method
   GrowableArray<oop>* oops_to_add = new GrowableArray<oop>();

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -261,25 +261,25 @@ void ResolvedMethodTable::adjust_method_entries_dcevm(bool * trace_name_printed)
 
       if (old_method->is_old()) {
 
+        InstanceKlass* newer_klass = InstanceKlass::cast(old_method->method_holder()->new_version());
+        Method* newer_method;
+
         // Method* new_method;
         if (old_method->is_deleted()) {
-          // FIXME:(DCEVM) - check if exception can be thrown
-          // new_method = Universe::throw_no_such_method_error();
-          continue;
-        }
+          newer_method = Universe::throw_no_such_method_error();
+        } else {
+          newer_method = newer_klass->method_with_idnum(old_method->orig_method_idnum());
 
-        InstanceKlass* newer_klass = InstanceKlass::cast(old_method->method_holder()->new_version());
-        Method* newer_method = newer_klass->method_with_idnum(old_method->orig_method_idnum());
+          log_info(redefine, class, load, exceptions)("Adjusting method: '%s' of new class %s", newer_method->name_and_sig_as_C_string(), newer_klass->name()->as_C_string());
 
-        log_info(redefine, class, load, exceptions)("Adjusting method: '%s' of new class %s", newer_method->name_and_sig_as_C_string(), newer_klass->name()->as_C_string());
+          assert(newer_klass == newer_method->method_holder(), "call after swapping redefined guts");
+          assert(newer_method != NULL, "method_with_idnum() should not be NULL");
+          assert(old_method != newer_method, "sanity check");
 
-        assert(newer_klass == newer_method->method_holder(), "call after swapping redefined guts");
-        assert(newer_method != NULL, "method_with_idnum() should not be NULL");
-        assert(old_method != newer_method, "sanity check");
-
-        if (_the_table->lookup(newer_method) != NULL) {
-          // old method was already adjusted if new method exists in _the_table
-            continue;
+          if (_the_table->lookup(newer_method) != NULL) {
+            // old method was already adjusted if new method exists in _the_table
+              continue;
+          }
         }
 
         java_lang_invoke_ResolvedMethodName::set_vmtarget(mem_name, newer_method);

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -200,7 +200,7 @@ void ResolvedMethodTable::print() {
 
 void ResolvedMethodTable::adjust_method_entries(bool * trace_name_printed) {
   assert(SafepointSynchronize::is_at_safepoint(), "only called at safepoint");
-  // For each entry in RMT, change to new method
+  // For each entry in RMT, change to new methodadjust_method_entries_dcevm
   for (int i = 0; i < _the_table->table_size(); ++i) {
     for (ResolvedMethodEntry* entry = _the_table->bucket(i);
          entry != NULL;
@@ -270,6 +270,8 @@ void ResolvedMethodTable::adjust_method_entries_dcevm(bool * trace_name_printed)
 
         InstanceKlass* newer_klass = InstanceKlass::cast(old_method->method_holder()->new_version());
         Method* newer_method = newer_klass->method_with_idnum(old_method->orig_method_idnum());
+
+        log_info(redefine, class, load, exceptions)("Adjusting method: '%s' of new class %s", newer_method->name_and_sig_as_C_string(), newer_klass->name()->as_C_string());
 
         assert(newer_klass == newer_method->method_holder(), "call after swapping redefined guts");
         assert(newer_method != NULL, "method_with_idnum() should not be NULL");

--- a/src/hotspot/share/prims/resolvedMethodTable.hpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.hpp
@@ -93,6 +93,7 @@ public:
 #if INCLUDE_JVMTI
   // It is called at safepoint only for RedefineClasses
   static void adjust_method_entries(bool * trace_name_printed);
+  static void adjust_method_entries_dcevm(bool * trace_name_printed);
 #endif // INCLUDE_JVMTI
 
   // Cleanup cleared entries

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -818,6 +818,7 @@ Unsafe_DefineAnonymousClass_impl(JNIEnv *env,
                                                 host_domain,
                                                 &st,
                                                 InstanceKlass::cast(host_klass),
+                                                NULL,
                                                 cp_patches,
                                                 CHECK_NULL);
   if (anonk == NULL) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4333,5 +4333,7 @@ void Arguments::setup_hotswap_agent() {
   create_numbered_property("jdk.module.addopens", "java.desktop/com.sun.beans=ALL-UNNAMED", addopens_count++);
   // com.sun.beans.introspect.ClassInfo access
   create_numbered_property("jdk.module.addopens", "java.desktop/com.sun.beans.introspect=ALL-UNNAMED", addopens_count++);
+  // com.sun.beans.introspect.util.Cache access
+  create_numbered_property("jdk.module.addopens", "java.desktop/com.sun.beans.util=ALL-UNNAMED", addopens_count++);
 
 }

--- a/src/java.desktop/share/classes/com/sun/beans/introspect/package-info.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.beans.introspect;

--- a/src/java.desktop/share/classes/com/sun/beans/package-info.java
+++ b/src/java.desktop/share/classes/com/sun/beans/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.beans;

--- a/src/java.desktop/share/classes/com/sun/beans/util/package-info.java
+++ b/src/java.desktop/share/classes/com/sun/beans/util/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.beans.util;

--- a/src/java.desktop/share/classes/module-info.java
+++ b/src/java.desktop/share/classes/module-info.java
@@ -104,6 +104,9 @@ module java.desktop {
     exports javax.swing.text.rtf;
     exports javax.swing.tree;
     exports javax.swing.undo;
+    exports com.sun.beans;
+    exports com.sun.beans.introspect;
+    exports com.sun.beans.util;
 
     // qualified exports may be inserted at build time
     // see make/GensrcModuleInfo.gmk


### PR DESCRIPTION
This pull request contains:
- formal code modifications such as comments improvements, std Oracle documentation formatting etc.
- opens for `com.sun.beans.util` package, that contains reflection cache. It is necessary to flush it after redefinition if reflection is used.
- improved separation of standard code from DCEVM, frequently used by checking flag `AllowEnhancedClassRedefinition`. Many asserts from standard JVM were comment out in the past, all of them are back now for `AllowEnhancedClassRedefinition=false` 
- dcevm has own adjusting method `adjust_method_entries_dcevm` in `ResolvedMethodTable`
- improved support for lambdas, it fixes https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/issues/21
- GC run after redefinition is skipped now if instance is not changed (level of  method or class modification). GC run is skipped in this way in dcevm7 and dcevm8. I've introduced full GC run after redefinition in dcevm11 since dcevm was more stable with it. I'm returning back to original code now since our long-term test does not crash now. Another reason for it is fact, that without full GC the redefinition is faster.
- Fix "no original bytecode found" - it fixes crashes if IDE deploys erroneous (partial) code
- Replace deleted method with Universe::throw_no_such_method_error - it is inspired by standard JDK code, that introduced it recently.
