### PR TITLE
G1 Heap parallel iterate method "object_par_iterate" + dcevm timers

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2108,6 +2108,21 @@ public:
   }
 };
 
+class G1IterateObjectClosureTask : public AbstractGangTask {
+ private:
+  ObjectClosure* _cl;
+  G1CollectedHeap* _g1h;
+  HeapRegionClaimer _hrclaimer;
+ public:
+  G1IterateObjectClosureTask(ObjectClosure* cl, G1CollectedHeap* g1h) : AbstractGangTask("IterateObject Closure"),
+    _cl(cl), _g1h(g1h),  _hrclaimer(g1h->workers()->active_workers()) { }
+
+  virtual void work(uint worker_id) {
+    IterateObjectClosureRegionClosure blk(_cl);
+    _g1h->heap_region_par_iterate_from_worker_offset(&blk, &_hrclaimer, worker_id);
+  }
+};
+
 void G1CollectedHeap::object_iterate(ObjectClosure* cl) {
   IterateObjectClosureRegionClosure blk(cl);
   heap_region_iterate(&blk);
@@ -2115,6 +2130,11 @@ void G1CollectedHeap::object_iterate(ObjectClosure* cl) {
 
 void G1CollectedHeap::heap_region_iterate(HeapRegionClosure* cl) const {
   _hrm.iterate(cl);
+}
+
+void G1CollectedHeap::object_par_iterate(ObjectClosure* cl) {
+  G1IterateObjectClosureTask iocl_task(cl, this);
+  workers()->run_task(&iocl_task);
 }
 
 void G1CollectedHeap::heap_region_par_iterate_from_worker_offset(HeapRegionClosure* cl,

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1117,6 +1117,8 @@ public:
 
   // Iteration functions.
 
+  void object_par_iterate(ObjectClosure* cl);
+
   // Iterate over all objects, calling "cl.do_object" on each.
   virtual void object_iterate(ObjectClosure* cl);
 

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
@@ -86,9 +86,10 @@ class VM_EnhancedRedefineClasses: public VM_GC_Operation {
   // Performance measurement support. These timers do not cover all
   // the work done for JVM/TI RedefineClasses() but they do cover
   // the heavy lifting.
-  elapsedTimer  _timer_rsc_phase1;
-  elapsedTimer  _timer_rsc_phase2;
+  elapsedTimer  _timer_vm_op_doit;
   elapsedTimer  _timer_vm_op_prologue;
+  elapsedTimer  _timer_heap_iterate;
+  elapsedTimer  _timer_heap_full_gc;
 
   // These routines are roughly in call order unless otherwise noted.
 


### PR DESCRIPTION
G1 Heap does not have parallel iterate method, that is usefull in dcevm
iterate phase. According performance tests the parallel iteration is up
~25% faster then serial iteration, ratio depends on the size of heap.
Dcevm's timers did not make sense. Now, there are timers fo prologue,
doit, gc itarate and full gc phases. Iterate+fullgc time make up most
the total doit time.