### PR TITLE
fix IDEA-147866, provide writeObjects implementation

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CClipboard.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CClipboard.java
@@ -89,7 +89,11 @@ final class CClipboard extends SunClipboard {
 
             try {
                 byte[] bytes = DataTransferer.getInstance().translateTransferable(contents, flavor, format);
-                setData(bytes, format);
+                if (DataFlavor.javaFileListFlavor.equals(flavor)) {
+                    writeObjects(bytes);
+                } else {
+                    setData(bytes, format);
+                }
             } catch (IOException e) {
                 // Fix 4696186: don't print exception if data with
                 // javaJVMLocalObjectMimeType failed to serialize.
@@ -127,6 +131,7 @@ final class CClipboard extends SunClipboard {
 
     private native void declareTypes(long[] formats, SunClipboard newOwner);
     private native void setData(byte[] data, long format);
+    private native void writeObjects(byte[] data);
 
     void checkPasteboardAndNotify() {
         if (checkPasteboardWithoutNotification()) {


### PR DESCRIPTION
A possible fix for [IDEA-147866](https://youtrack.jetbrains.com/issue/IDEA-147866) and [IDEA-109567](https://youtrack.jetbrains.com/issue/IDEA-109567)
Some background:
Originally the implementation used ``NSPasteboard.sendData`` with the format ``NSFilenamesPboardType``. Unfortunately ``NSFilenamesPboardType`` [is deprecated and removed after 10.14](https://developer.apple.com/documentation/appkit/nsfilenamespboardtype). 

The suggested replacement is ``NSPasteboard.writeObjects`` method with an array of ``NSURL``.

Looks like ``NSURL`` and ``NSPasteboard.writeObjects`` are available since  10.6+ so it looks safe enough to just replace the old behavior with the new one without any changes for backward-compatibility.

There is an alternative solution without the jdk fix: https://plugins.jetbrains.com/plugin/13517-copytofinder but I don't think that we need one more native library in IJ code base
