### PR TITLE
Follow-up to 8221852: reporting actual error when unprivileged symlink creation fails

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsNativeDispatcher.java
@@ -944,9 +944,12 @@ class WindowsNativeDispatcher {
                     CreateSymbolicLink0(linkBuffer.address(),
                                         targetBuffer.address(), flags);
                     return;
-                } catch (WindowsException ignored) {
+                } catch (WindowsException xx) {
                     // Will fail with ERROR_INVALID_PARAMETER for Windows
                     // builds older than 14972.
+                    if (xx.lasError() != ERROR_INVALID_PARAMETER) {
+                        x = xx;
+                    }
                 }
             }
             throw x;


### PR DESCRIPTION
... for a reason other that ERROR_INVALID_PARAMETER.