### PR TITLE
JBR-3068: Updated common Windows file/folder selection dialogs

### DIFF
--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -632,4 +632,25 @@ public class FileDialog extends Dialog {
     boolean postsOldMouseEvents() {
         return false;
     }
+
+    /**
+     * Text for "Open" button (used when common file dialogs are enabled on
+     * Windows).
+     */
+    private String openButtonText;
+
+    /**
+     * Text for "Select Folder" button (used when common file dialogs are
+     * enabled on Windows).
+     */
+    private String selectFolderButtonText;
+
+    /**
+     * Called using reflection; sets localization strings used when common
+     * file dialogs are enabled on Windows.
+     */
+    private void setLocalizationStrings(String openButtonText, String selectFolderButtonText) {
+        this.openButtonText = openButtonText;
+        this.selectFolderButtonText = selectFolderButtonText;
+    }
 }

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -653,4 +653,14 @@ public class FileDialog extends Dialog {
         this.openButtonText = openButtonText;
         this.selectFolderButtonText = selectFolderButtonText;
     }
+
+    /**
+     * Whether to enable folder picker mode (used when common file dialogs are
+     * enabled on Windows).
+     */
+    private boolean folderPickerMode;
+
+    private void setFolderPickerMode(boolean folderPickerMode) {
+        this.folderPickerMode = folderPickerMode;
+    }
 }

--- a/src/java.desktop/share/classes/java/awt/FileDialog.java
+++ b/src/java.desktop/share/classes/java/awt/FileDialog.java
@@ -663,4 +663,14 @@ public class FileDialog extends Dialog {
     private void setFolderPickerMode(boolean folderPickerMode) {
         this.folderPickerMode = folderPickerMode;
     }
+
+    /**
+     * Whether to enable exclusive file picker mode, with no folder picker
+     * available (used when common file dialogs are enabled on Windows).
+     */
+    private boolean fileExclusivePickerMode;
+
+    private void setFileExclusivePickerMode(boolean fileExclusivePickerMode) {
+        this.fileExclusivePickerMode = fileExclusivePickerMode;
+    }
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
@@ -56,6 +56,7 @@ jfieldID AwtFileDialog::filterID;
 jfieldID AwtFileDialog::openButtonTextID;
 jfieldID AwtFileDialog::selectFolderButtonTextID;
 jfieldID AwtFileDialog::folderPickerModeID;
+jfieldID AwtFileDialog::fileExclusivePickerModeID;
 
 class CoTaskStringHolder {
 public:
@@ -631,14 +632,12 @@ public:
     };
 
     IFACEMETHODIMP OnFileOk(IFileDialog *) {
-        if (!data->ignoreCustomizations) {
-            OLE_TRY
-                OLE_HRT(GetSelectedResults(data));
-            OLE_CATCH
+        OLE_TRY
+            OLE_HRT(GetSelectedResults(data));
+        OLE_CATCH
 
-            // Since the user has chosen a file, reset the forceUseContainerFolder mode.
-            data->forceUseContainerFolder = FALSE;
-        }
+        // Since the user has chosen a file, reset the forceUseContainerFolder mode.
+        data->forceUseContainerFolder = FALSE;
 
         return S_OK;
     };
@@ -924,7 +923,8 @@ AwtFileDialog::Show(void *p)
             OLE_HRT(pfd.CreateInstance(fileDialogMode));
 
             bool folderPickerMode = env->GetBooleanField(target, AwtFileDialog::folderPickerModeID);
-            data.ignoreCustomizations = folderPickerMode || mode == java_awt_FileDialog_SAVE;
+            bool fileExclusivePickerMode = env->GetBooleanField(target, AwtFileDialog::fileExclusivePickerModeID);
+            data.ignoreCustomizations = folderPickerMode || fileExclusivePickerMode || mode == java_awt_FileDialog_SAVE;
             data.fileDialog = pfd;
             data.peer = peer;
             SaveCommonDialogLocalizationData(env, target, data);
@@ -1230,6 +1230,10 @@ Java_sun_awt_windows_WFileDialogPeer_initIDs(JNIEnv *env, jclass cls)
     AwtFileDialog::folderPickerModeID = env->GetFieldID(cls, "folderPickerMode", "Z");
     DASSERT(AwtFileDialog::folderPickerModeID != NULL);
     CHECK_NULL(AwtFileDialog::folderPickerModeID);
+
+    AwtFileDialog::fileExclusivePickerModeID = env->GetFieldID(cls, "fileExclusivePickerMode", "Z");
+    DASSERT(AwtFileDialog::fileExclusivePickerModeID != NULL);
+    CHECK_NULL(AwtFileDialog::fileExclusivePickerModeID);
 
     CATCH_BAD_ALLOC;
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.h
@@ -58,6 +58,7 @@ public:
     static jfieldID filterID;
     static jfieldID openButtonTextID;
     static jfieldID selectFolderButtonTextID;
+    static jfieldID folderPickerModeID;
 
     static void Initialize(JNIEnv *env, jstring filterDescription);
     static void Show(void *peer);

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.h
@@ -56,6 +56,8 @@ public:
     static jfieldID dirID;
     static jfieldID fileID;
     static jfieldID filterID;
+    static jfieldID openButtonTextID;
+    static jfieldID selectFolderButtonTextID;
 
     static void Initialize(JNIEnv *env, jstring filterDescription);
     static void Show(void *peer);

--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.h
@@ -59,6 +59,7 @@ public:
     static jfieldID openButtonTextID;
     static jfieldID selectFolderButtonTextID;
     static jfieldID folderPickerModeID;
+    static jfieldID fileExclusivePickerModeID;
 
     static void Initialize(JNIEnv *env, jstring filterDescription);
     static void Show(void *peer);


### PR DESCRIPTION
See [JBR-3068](https://youtrack.jetbrains.com/issue/JBR-3068) for details, QA check list and the test program. These changes are supposed to fix every "×" mark in the check list.

The corresponding IntelliJ changes are to just call private JBR APIs in `FileDialog` class.

I've tried to move my private APIs to `WFileDialogPeer`, but there's no user-visible APIs to get `WFileDialogPeer` from the `FileDialog`, so finally I've decided to move them to the `FileDialog` itself.