### PR TITLE
RIDER-57780: reload state of native file dialogs each time

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_FileDialog.cpp
@@ -814,7 +814,7 @@ AwtFileDialog::Show(void *p)
 
     LPTSTR fileBuffer = NULL;
 
-    static BOOL useCommonItemDialog = JNU_CallStaticMethodByName(env, NULL,
+    BOOL useCommonItemDialog = JNU_CallStaticMethodByName(env, NULL,
             "sun/awt/windows/WFileDialogPeer", "useCommonItemDialog", "()Z").z == JNI_TRUE;
     try {
         DASSERT(peer);


### PR DESCRIPTION
To work around [RIDER-57780](https://youtrack.jetbrains.com/issue/RIDER-57780), we need to switch common file dialogs on an off at runtime sometimes. This PR allows us to do it (JBR will reload the state of the `useCommonItemDialog` property every time a new dialog is instantiated).

This shouldn't affect any other products than Rider, since nobody else uses the native file dialogs of any kind.