### PR TITLE
fix more regressions after pull/73

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -694,7 +694,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_LWCToolkit_isApplicationActive
 AWT_ASSERT_NOT_APPKIT_THREAD;
 JNI_COCOA_ENTER(env);
 
-        [ThreadUtilities performOnMainThreadWaiting:YES withBlock:^() {
+        [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
                 active = (jboolean)[NSRunningApplication currentApplication].active;
         }];
 


### PR DESCRIPTION
The following test passes with output:

----------System.err:(11/838)----------
2021-08-12 15:55:49.320 java[93383:2815604] +[ThreadUtilities performOnMainThreadWaiting:withBlock:]: unrecognized selector sent to class 0x10d7350e0
2021-08-12 15:55:49.320 java[93383:2815604] (
   0   CoreFoundation                      0x00007fff2073d87b __exceptionPreprocess + 242
   1   libobjc.A.dylib                     0x00007fff20475d92 objc_exception_throw + 48
   2   CoreFoundation                      0x00007fff207c02e5 __CFExceptionProem + 0
   3   CoreFoundation                      0x00007fff206a590b ___forwarding___ + 1448
   4   CoreFoundation                      0x00007fff206a52d8 _CF_forwarding_prep_0 + 120
   5   libawt_lwawt.dylib                  0x000000010d687d4f Java_sun_lwawt_macosx_LWCToolkit_isApplicationActive + 226
   6   ???                                 0x0000000116e91a10 0x0 + 4679342608
)
STATUS:Passed.