### PR TITLE
Fix IDEA-196116: Don't touch the active keyboard layout on input method activation / deactivation

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java
@@ -168,10 +168,6 @@ final class WInputMethod extends InputMethodAdapter
 
     @Override
     public boolean setLocale(Locale lang) {
-        return setLocale(lang, false);
-    }
-
-    private boolean setLocale(Locale lang, boolean onActivate) {
         Locale[] available = WInputMethodDescriptor.getAvailableLocalesInternal();
         for (int i = 0; i < available.length; i++) {
             Locale locale = available[i];
@@ -180,7 +176,7 @@ final class WInputMethod extends InputMethodAdapter
                     locale.equals(Locale.JAPAN) && lang.equals(Locale.JAPANESE) ||
                     locale.equals(Locale.KOREA) && lang.equals(Locale.KOREAN)) {
                 if (isActive) {
-                    setNativeLocale(locale.toLanguageTag(), onActivate);
+                    setNativeLocale(locale.toLanguageTag());
                 }
                 currentLocale = locale;
                 return true;
@@ -319,9 +315,6 @@ final class WInputMethod extends InputMethodAdapter
             isLastFocussedActiveClient = isAc;
         }
         isActive = true;
-        if (currentLocale != null) {
-            setLocale(currentLocale, true);
-        }
 
         // Compare IM's composition string with Java's composition string
         if (hasCompositionString && !isCompositionStringAvailable(context)) {
@@ -348,10 +341,6 @@ final class WInputMethod extends InputMethodAdapter
     @Override
     public void deactivate(boolean isTemporary)
     {
-        // Sync currentLocale with the Windows keyboard layout which might be changed
-        // by hot key
-        getLocale();
-
         // Delay calling disableNativeIME until activate is called and the newly
         // focussed component has a different peer as the last focussed component.
         if (awtFocussedComponentPeer != null) {
@@ -667,7 +656,7 @@ final class WInputMethod extends InputMethodAdapter
     private native void setStatusWindowVisible(WComponentPeer peer, boolean visible);
     private native String getNativeIMMDescription();
     static native Locale getNativeLocale();
-    static native boolean setNativeLocale(String localeName, boolean onActivate);
+    static native boolean setNativeLocale(String localeName);
     private native void openCandidateWindow(WComponentPeer peer, int x, int y);
     private native boolean isCompositionStringAvailable(int context);
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -88,15 +88,6 @@ static DCList passiveDCList;
 
 extern void CheckFontSmoothingSettings(HWND);
 
-extern "C" {
-    // Remember the input language has changed by some user's action
-    // (Alt+Shift or through the language icon on the Taskbar) to control the
-    // race condition between the toolkit thread and the AWT event thread.
-    // This flag remains TRUE until the next WInputMethod.getNativeLocale() is
-    // issued.
-    BOOL g_bUserHasChangedInputLang = FALSE;
-}
-
 BOOL AwtComponent::sm_suppressFocusAndActivation = FALSE;
 BOOL AwtComponent::sm_restoreFocusAndActivation = FALSE;
 HWND AwtComponent::sm_focusOwner = NULL;
@@ -1900,9 +1891,6 @@ LRESULT AwtComponent::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
           ::ToAsciiEx(VK_SPACE, ::MapVirtualKey(VK_SPACE, 0),
                       keyboardState, &ignored, 0, GetKeyboardLayout());
 
-          // Set this flag to block ActivateKeyboardLayout from
-          // WInputMethod.activate()
-          g_bUserHasChangedInputLang = TRUE;
           CallProxyDefWindowProc(message, wParam, lParam, retValue, mr);
           break;
       }
@@ -1911,7 +1899,6 @@ LRESULT AwtComponent::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
                           "new = 0x%08X",
                           GetHWnd(), GetClassName(), (UINT)lParam);
           mr = WmInputLangChange(static_cast<UINT>(wParam), reinterpret_cast<HKL>(lParam));
-          g_bUserHasChangedInputLang = TRUE;
           CallProxyDefWindowProc(message, wParam, lParam, retValue, mr);
           // should return non-zero if we process this message
           retValue = 1;

--- a/src/java.desktop/windows/native/libawt/windows/awt_InputMethod.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_InputMethod.cpp
@@ -44,8 +44,6 @@ extern "C" {
 jobject CreateLocaleObject(JNIEnv *env, const char * name);
 HKL getDefaultKeyboardLayout();
 
-extern BOOL g_bUserHasChangedInputLang;
-
 /*
  * Class:     sun_awt_windows_WInputMethod
  * Method:    createNativeContext
@@ -292,10 +290,6 @@ JNIEXPORT jobject JNICALL Java_sun_awt_windows_WInputMethod_getNativeLocale
 
     const char * javaLocaleName = getJavaIDFromLangID(AwtComponent::GetInputLanguage());
     if (javaLocaleName != NULL) {
-        // Now WInputMethod.currentLocale and AwtComponent::m_idLang are get sync'ed,
-        // so we can reset this flag.
-        g_bUserHasChangedInputLang = FALSE;
-
         jobject ret = CreateLocaleObject(env, javaLocaleName);
         free((void *)javaLocaleName);
         return ret;
@@ -309,10 +303,10 @@ JNIEXPORT jobject JNICALL Java_sun_awt_windows_WInputMethod_getNativeLocale
 /*
  * Class:     sun_awt_windows_WInputMethod
  * Method:    setNativeLocale
- * Signature: (Ljava/lang/String;Z)Z
+ * Signature: (Ljava/lang/String;)Z
  */
 JNIEXPORT jboolean JNICALL Java_sun_awt_windows_WInputMethod_setNativeLocale
-  (JNIEnv *env, jclass cls, jstring localeString, jboolean onActivate)
+  (JNIEnv *env, jclass cls, jstring localeString)
 {
     TRY;
 
@@ -353,7 +347,7 @@ JNIEXPORT jboolean JNICALL Java_sun_awt_windows_WInputMethod_setNativeLocale
         if (supported != NULL) {
             if (strcmp(supported, requested) == 0) {
                 // use special message to call ActivateKeyboardLayout() in main thread.
-                if (AwtToolkit::GetInstance().SendMessage(WM_AWT_ACTIVATEKEYBOARDLAYOUT, (WPARAM)onActivate, (LPARAM)hKLList[i])) {
+                if (AwtToolkit::GetInstance().SendMessage(WM_AWT_ACTIVATEKEYBOARDLAYOUT, NULL, (LPARAM)hKLList[i])) {
                     //also need to change the same keyboard layout for the Java AWT-EventQueue thread
                     AwtToolkit::activateKeyboardLayout(hKLList[i]);
                     retValue = JNI_TRUE;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -71,7 +71,6 @@ extern void initScreens(JNIEnv *env);
 extern "C" void awt_dnd_initialize();
 extern "C" void awt_dnd_uninitialize();
 extern "C" void awt_clipboard_uninitialize(JNIEnv *env);
-extern "C" BOOL g_bUserHasChangedInputLang;
 
 extern CriticalSection windowMoveLock;
 extern BOOL windowMoveLockHeld;
@@ -1235,14 +1234,6 @@ LRESULT CALLBACK AwtToolkit::WndProc(HWND hWnd, UINT message,
           return cmode;
       }
       case WM_AWT_ACTIVATEKEYBOARDLAYOUT: {
-          if (wParam && g_bUserHasChangedInputLang) {
-              // Input language has been changed since the last WInputMethod.getNativeLocale()
-              // call.  So let's honor the user's selection.
-              // Note: we need to check this flag inside the toolkit thread to synchronize access
-              // to the flag.
-              return FALSE;
-          }
-
           if (lParam == (LPARAM)::GetKeyboardLayout(0)) {
               // already active
               return FALSE;


### PR DESCRIPTION
This is a fix for [IDEA-196116](https://youtrack.jetbrains.com/issue/IDEA-196116): essentially, I propose to stop touching the active layout on frame / input method activation/deactivation, and let the OS to do all the work.