### PR TITLE
Jbr dev vmops

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -118,6 +118,8 @@ bool Arguments::_has_jimage = false;
 
 char* Arguments::_ext_dirs = NULL;
 
+GrowableArray<const char *> *Arguments::_unrecognized_vm_options = NULL;
+
 bool PathString::set_value(const char *value) {
   if (_value != NULL) {
     FreeHeap(_value);
@@ -1225,8 +1227,10 @@ bool Arguments::process_argument(const char* arg,
     }
   } else {
     if (ignore_unrecognized) {
+      store_unrecognized_vm_option(arg);
       return true;
     }
+
     jio_fprintf(defaultStream::error_stream(),
                 "Unrecognized VM option '%s'\n", argname);
     JVMFlag* fuzzy_matched = JVMFlag::fuzzy_match((const char*)argname, arg_len, true);
@@ -1237,7 +1241,7 @@ bool Arguments::process_argument(const char* arg,
                   fuzzy_matched->name(),
                   (fuzzy_matched->is_bool()) ? "" : "=<value>");
     }
-  }
+ }
 
   // allow for commandline "commenting out" options like -XX:#+Verbose
   return arg[0] == '#';
@@ -2014,9 +2018,38 @@ bool Arguments::check_vm_args_consistency() {
   return status;
 }
 
+void Arguments::set_unrecognized_vm_options_property() {
+  if (_unrecognized_vm_options != NULL) {
+    int num_of_entries = _unrecognized_vm_options->length();
+    const char* option_string = _unrecognized_vm_options->at(0);
+
+    SystemProperty* prop = new SystemProperty("java.vm.unrecognized.options", "", true, false);
+
+    prop->set_value(option_string);
+
+    for (int i = 1; i < num_of_entries; i++) {
+      option_string = _unrecognized_vm_options->at(i);
+      prop->append_value(option_string);
+    }
+
+    PropertyList_add(&_system_properties, prop);
+  }
+}
+
+void Arguments::store_unrecognized_vm_option(const char* option) {
+  if (_unrecognized_vm_options == NULL) {
+    // Create GrowableArray lazily, only if unrecognized vm options found
+    _unrecognized_vm_options = new (ResourceObj::C_HEAP, mtArguments) GrowableArray<const char *>(10, mtArguments);
+  }
+  _unrecognized_vm_options->push(option);
+}
+
 bool Arguments::is_bad_option(const JavaVMOption* option, jboolean ignore,
   const char* option_type) {
-  if (ignore) return false;
+  if (ignore) {
+     store_unrecognized_vm_option(option->optionString);
+     return false;
+  }
 
   const char* spacer = " ";
   if (option_type == NULL) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2029,7 +2029,7 @@ void Arguments::set_unrecognized_vm_options_property() {
 
     for (int i = 1; i < num_of_entries; i++) {
       option_string = _unrecognized_vm_options->at(i);
-      prop->append_value(option_string, " ");
+      prop->append_value(option_string, "\n");
     }
 
     PropertyList_add(&_system_properties, prop);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -135,7 +135,7 @@ bool PathString::set_value(const char *value) {
   return true;
 }
 
-void PathString::append_value(const char *value) {
+void PathString::append_value(const char *value, const char *separator) {
   char *sp;
   size_t len = 0;
   if (value != NULL) {
@@ -148,7 +148,7 @@ void PathString::append_value(const char *value) {
     if (sp != NULL) {
       if (_value != NULL) {
         strcpy(sp, _value);
-        strcat(sp, os::path_separator());
+        strcat(sp, separator);
         strcat(sp, value);
         FreeHeap(_value);
       } else {
@@ -2029,7 +2029,7 @@ void Arguments::set_unrecognized_vm_options_property() {
 
     for (int i = 1; i < num_of_entries; i++) {
       option_string = _unrecognized_vm_options->at(i);
-      prop->append_value(option_string);
+      prop->append_value(option_string, " ");
     }
 
     PropertyList_add(&_system_properties, prop);

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -67,7 +67,8 @@ class PathString : public CHeapObj<mtArguments> {
   char* value() const { return _value; }
 
   bool set_value(const char *value);
-  void append_value(const char *value);
+  void append_value(const char *value, const char *delemiter);
+  void append_value(const char *value) { append_value(value, os::path_separator()); }
 
   PathString(const char* value);
   ~PathString();

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -352,6 +352,10 @@ class Arguments : AllStatic {
   static void set_xdebug_mode(bool arg) { _xdebug_mode = arg; }
   static bool xdebug_mode()             { return _xdebug_mode; }
 
+  // List of unrecognized VM options
+  static GrowableArray<const char *> *_unrecognized_vm_options;
+  static void store_unrecognized_vm_option(const char* option);
+
   // preview features
   static bool _enable_preview;
 
@@ -564,6 +568,9 @@ class Arguments : AllStatic {
 
   // Update/Initialize System properties after JDK version number is known
   static void init_version_specific_system_properties();
+
+  // Store unrecognized vm options to system property
+  static void set_unrecognized_vm_options_property();
 
   // Update VM info property - called after argument parsing
   static void update_vm_info_property(const char* vm_info) {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1016,7 +1016,7 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, PrintVMOptions, false,                                      \
           "Print flags that appeared on the command line")                  \
                                                                             \
-  product(bool, IgnoreUnrecognizedVMOptions, false,                         \
+  product(bool, IgnoreUnrecognizedVMOptions, true,                          \
           "Ignore unrecognized VM options")                                 \
                                                                             \
   product(bool, PrintCommandLineFlags, false,                               \

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2723,6 +2723,10 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   MemTracker::initialize();
 #endif // INCLUDE_NMT
 
+  // Store all unrecognized vm options to system property
+  // to make it accessible from Java
+  Arguments::set_unrecognized_vm_options_property();
+
   os::init_before_ergo();
 
   jint ergo_result = Arguments::apply_ergo();

--- a/test/hotspot/jtreg/runtime/CommandLine/ConfigFileWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/ConfigFileWarning.java
@@ -46,7 +46,7 @@ public class ConfigFileWarning {
         pw.println("aaa");
         pw.close();
 
-        pb = ProcessTools.createJavaProcessBuilder("-XX:Flags=hs_flags.txt","-version");
+        pb = ProcessTools.createJavaProcessBuilder("-XX:Flags=hs_flags.txt","-XX:-IgnoreUnrecognizedVMOptions","-version");
         output = new OutputAnalyzer(pb.start());
         output.shouldContain("Unrecognized VM option 'aaa'");
         output.shouldHaveExitValue(1);

--- a/test/hotspot/jtreg/runtime/CommandLine/TestLongUnrecognizedVMOption.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/TestLongUnrecognizedVMOption.java
@@ -42,7 +42,7 @@ public class TestLongUnrecognizedVMOption {
     public static void main(String[] args) throws Exception {
         OutputAnalyzer output;
 
-        output = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder("-XX:" + VERY_LONG_OPTION, "-version").start());
+        output = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder("-XX:" + VERY_LONG_OPTION,"-XX:-IgnoreUnrecognizedVMOptions","-version").start());
         output.shouldHaveExitValue(1);
         output.shouldContain(String.format("Unrecognized VM option '%s'", VERY_LONG_OPTION));
     }

--- a/test/hotspot/jtreg/runtime/CommandLine/TestNullTerminatedFlags.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/TestNullTerminatedFlags.java
@@ -57,7 +57,7 @@ public class TestNullTerminatedFlags {
         for (String option : options) {
             String testOption = option + "junk";
             ProcessBuilder pb =
-                ProcessTools.createJavaProcessBuilder(testOption, "-version");
+                ProcessTools.createJavaProcessBuilder(testOption, "-XX:-IgnoreUnrecognizedVMOptions", "-version");
             new OutputAnalyzer(pb.start())
                     .shouldContain("Unrecognized option: " + testOption)
                     .shouldHaveExitValue(1);

--- a/test/hotspot/jtreg/runtime/CommandLine/UnrecognizedVMOptionsProperty.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/UnrecognizedVMOptionsProperty.java
@@ -28,27 +28,18 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver UnrecognizedVMOption
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xverify:BadV -XX-BadSyn -Bad -XX:+BadXX01 -XX:+BadXX02 -XX:+Bad:SC UnrecognizedVMOptionsProperty
  */
 
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 
-public class UnrecognizedVMOption {
+public class UnrecognizedVMOptionsProperty {
   public static void main(String[] args) throws Exception {
-    // Note: -XX by itself is an unrecognized launcher option, the :
-    // must be present for it to be passed through as a VM option.
-    String[] badOptions = {
-      "",  // empty option
-      "bogus_option",
-    };
-    for (String option : badOptions) {
-      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-          "-XX:" + option, "-XX:-IgnoreUnrecognizedVMOptions", "-version");
-
-      OutputAnalyzer output = new OutputAnalyzer(pb.start());
-      output.shouldContain("Unrecognized VM option '" + option + "'");
-      output.shouldHaveExitValue(1);
-    }
+     String badOptions = System.getProperty("java.vm.unrecognized.options");
+     System.out.println("Found unrecognized VM options " + badOptions);
+     if (! badOptions.equals("-Xverify:BadV:-XX-BadSyn:-Bad:+BadXX01:+BadXX02:+Bad:SC")) {
+        throw new RuntimeException("Invalid value of 'java.vm.unrecognized.options' property '" + badOptions + "'");
+     }
   }
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/UnrecognizedVMOptionsProperty.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/UnrecognizedVMOptionsProperty.java
@@ -38,7 +38,7 @@ public class UnrecognizedVMOptionsProperty {
   public static void main(String[] args) throws Exception {
      String badOptions = System.getProperty("java.vm.unrecognized.options");
      System.out.println("Found unrecognized VM options " + badOptions);
-     if (! badOptions.equals("-Xverify:BadV:-XX-BadSyn:-Bad:+BadXX01:+BadXX02:+Bad:SC")) {
+     if (! badOptions.equals("-Xverify:BadV -XX-BadSyn -Bad +BadXX01 +BadXX02 +Bad:SC")) {
         throw new RuntimeException("Invalid value of 'java.vm.unrecognized.options' property '" + badOptions + "'");
      }
   }

--- a/test/hotspot/jtreg/runtime/CommandLine/UnrecognizedVMOptionsProperty.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/UnrecognizedVMOptionsProperty.java
@@ -38,7 +38,7 @@ public class UnrecognizedVMOptionsProperty {
   public static void main(String[] args) throws Exception {
      String badOptions = System.getProperty("java.vm.unrecognized.options");
      System.out.println("Found unrecognized VM options " + badOptions);
-     if (! badOptions.equals("-Xverify:BadV -XX-BadSyn -Bad +BadXX01 +BadXX02 +Bad:SC")) {
+     if (! badOptions.equals("-Xverify:BadV\n-XX-BadSyn\n-Bad\n+BadXX01\n+BadXX02\n+Bad:SC")) {
         throw new RuntimeException("Invalid value of 'java.vm.unrecognized.options' property '" + badOptions + "'");
      }
   }

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -37,7 +37,7 @@ import jdk.test.lib.Platform;
 
 public class VMOptionWarning {
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+AlwaysSafeConstructors", "-version");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+AlwaysSafeConstructors", "-XX:-IgnoreUnrecognizedVMOptions", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'AlwaysSafeConstructors' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.");
@@ -47,17 +47,17 @@ public class VMOptionWarning {
             return;
         }
 
-        pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintInlining", "-version");
+        pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintInlining", "-XX:-IgnoreUnrecognizedVMOptions", "-version");
         output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'PrintInlining' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
 
-        pb = ProcessTools.createJavaProcessBuilder("-XX:+VerifyStack", "-version");
+        pb = ProcessTools.createJavaProcessBuilder("-XX:+VerifyStack", "-XX:-IgnoreUnrecognizedVMOptions", "-version");
         output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'VerifyStack' is develop and is available only in debug version of VM.");
 
-        pb = ProcessTools.createJavaProcessBuilder("-XX:+CheckCompressedOops", "-version");
+        pb = ProcessTools.createJavaProcessBuilder("-XX:+CheckCompressedOops", "-XX:-IgnoreUnrecognizedVMOptions", "-version");
         output = new OutputAnalyzer(pb.start());
         output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'CheckCompressedOops' is notproduct and is available only in debug version of VM.");

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionsFile/TestVMOptionsFile.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionsFile/TestVMOptionsFile.java
@@ -242,6 +242,7 @@ public class TestVMOptionsFile {
     private static ProcessBuilder createProcessBuilder() throws Exception {
         ProcessBuilder pb;
         List<String> runJava = new ArrayList<>();
+        runJava.add("-XX:-IgnoreUnrecognizedVMOptions");
 
         runJava.addAll(VMParams);
         runJava.add(PrintPropertyAndOptions.class.getName());


### PR DESCRIPTION
This patch:

1.  Change default behavior to ignore unrecognized options (+IgnoreUnrecognizedVMOptions)

2. Store all ignored values to: "java.vm.unrecognized.options" as "+BogusOption01 +BogusOption02" (space separated), see testcase

3. Explicitly set -IgnoreUnrecognizedVMOptions for couple of tests, that rely on default behavior

PS: Default separator for multiple values in property provided by os::path_separator() function, this behavior changed by second commit. The separator hard coded to " " (space)