### PR TITLE
macOS: add methods to setup transparent titlebar with custom height

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -104,7 +104,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
     static native CPlatformWindow nativeGetTopmostPlatformWindowUnderMouse();
     private static native boolean nativeDelayShowing(long nsWindowPtr);
     private static native void nativeRaiseLevel(long nsWindowPtr, boolean popup, boolean onlyIfParentIsActive);
-    private static native void nativeTransparentTitleBarWithCustomHeight(long nsWindowPtr, float height);
+    private static native void nativeSetTransparentTitleBarHeight(long nsWindowPtr, float height);
 
     // Loger to report issues happened during execution but that do not affect functionality
     private static final PlatformLogger logger = PlatformLogger.getLogger("sun.lwawt.macosx.CPlatformWindow");
@@ -137,6 +137,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
     public static final String WINDOW_TRANSPARENT_TITLE_BAR = "apple.awt.transparentTitleBar";
     public static final String WINDOW_TITLE_VISIBLE = "apple.awt.windowTitleVisible";
     public static final String WINDOW_APPEARANCE = "apple.awt.windowAppearance";
+    public static final String WINDOW_TRANSPARENT_TITLE_BAR_HEIGHT = "apple.awt.windowTransparentTitleBarHeight";
 
     // This system property is named as jdk.* because it is not specific to AWT
     // and it is also used in JavaFX
@@ -283,6 +284,13 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
             public void applyProperty(final CPlatformWindow c, final Object value) {
                 if (value != null && (value instanceof String)) {
                     c.execute(ptr -> nativeSetNSWindowAppearance(ptr, (String) value));
+                }
+            }
+        },
+        new Property<CPlatformWindow>(WINDOW_TRANSPARENT_TITLE_BAR_HEIGHT) {
+            public void applyProperty(final CPlatformWindow c, final Object value) {
+                if (value != null && (value instanceof Float)) {
+                    c.execute(ptr -> nativeSetTransparentTitleBarHeight(ptr, (float) value));
                 }
             }
         }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -1456,6 +1456,13 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         isFullScreenAnimationOn = false;
     }
 
+    // called from client via reflection
+    private void setTransparentTitleBarHeight(float height) {
+        execute(ptr -> {
+            nativeSetTransparentTitleBarHeight(ptr, height);
+        });
+    }
+
     private volatile List<Rectangle> customDecorHitTestSpots;
 
     // called from client via reflection

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
@@ -49,7 +49,6 @@
     BOOL isJustCreated;
     NSWindowTabbingMode javaWindowTabbingMode;
     BOOL isEnterFullScreen;
-    BOOL _titlebarDisabled;
     CGFloat _customHeaderHeight;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
@@ -49,6 +49,8 @@
     BOOL isJustCreated;
     NSWindowTabbingMode javaWindowTabbingMode;
     BOOL isEnterFullScreen;
+    BOOL _titlebarDisabled;
+    CGFloat _customHeaderHeight;
 }
 
 // An instance of either AWTWindow_Normal or AWTWindow_Panel
@@ -102,6 +104,11 @@
               frameRect:(NSRect)rect
               styleMask:(NSUInteger)styleMask
             contentView:(NSView *)view;
+@end
+
+@interface AWTWindowDragView : NSView
+@property (nonatomic) jobject javaPlatformWindow;
+- (id) initWithPlatformWindow:(jobject)javaPlatformWindow;
 @end
 
 #endif _AWTWINDOW_H

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
@@ -49,7 +49,9 @@
     BOOL isJustCreated;
     NSWindowTabbingMode javaWindowTabbingMode;
     BOOL isEnterFullScreen;
-    CGFloat _customHeaderHeight;
+    CGFloat _transparentTitleBarHeight;
+    NSLayoutConstraint *_transparentTitleBarHeightConstraint;
+    NSMutableArray *_transparentTitleBarButtonCenterXConstraints;
 }
 
 // An instance of either AWTWindow_Normal or AWTWindow_Panel

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1394,7 +1394,6 @@ AWT_ASSERT_APPKIT_THREAD;
         [self setUpCustomHeader];
         [self setWindowControlsHidden:NO];
     }];
-    _titlebarDisabled = YES;
 }
 
 @end // AWTWindow

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -2231,7 +2231,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeDelayShow
 }
 
 
-JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeTransparentTitleBarWithCustomHeight
+JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetTransparentTitleBarHeight
 (JNIEnv *env, jclass clazz, jlong windowPtr, jfloat customHeaderHeight)
 {
     JNI_COCOA_ENTER(env);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1246,7 +1246,8 @@ AWT_ASSERT_APPKIT_THREAD;
     NSView* titlebarDecoration = titlebarContainer.subviews[1];
 
     // The following two views are only there on Big Sur and forward
-    BOOL runningAtLeastBigSur = @available(macOS 11.0, *);
+    BOOL runningAtLeastBigSur = [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 11;
+    
     NSView* titlebarVisualEffect = runningAtLeastBigSur ? titlebar.subviews[0] : nil;
     NSView* titlebarBackground = runningAtLeastBigSur ? titlebar.subviews[1] : nil;
 
@@ -1319,7 +1320,7 @@ AWT_ASSERT_APPKIT_THREAD;
     NSView* titlebarDecoration = titlebarContainer.subviews[1];
 
     // The following two views are only there on Big Sur and forward
-    BOOL runningAtLeastBigSur = @available(macOS 11.0, *);
+    BOOL runningAtLeastBigSur = [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 11;
     NSView* titlebarVisualEffect = runningAtLeastBigSur ? titlebar.subviews[0] : nil;
     NSView* titlebarBackground = runningAtLeastBigSur ? titlebar.subviews[1] : nil;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1320,8 +1320,6 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
 
 - (void) resetTitleBar
 {
-    BOOL runningAtLeastMojave = IS_OSX_GT10_13;
-    BOOL runningAtLeastBigSur = IS_OSX_GT10_15;
     // See [setUpTransparentTitleBar] for the view hierarchy we're working with
     NSView* closeButtonView = [self.nsWindow standardWindowButton:NSWindowCloseButton];
     NSView* zoomButtonView = [self.nsWindow standardWindowButton:NSWindowZoomButton];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1247,7 +1247,7 @@ AWT_ASSERT_APPKIT_THREAD;
 
     // The following two views are only there on Big Sur and forward
     BOOL runningAtLeastBigSur = [[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 11;
-    
+
     NSView* titlebarVisualEffect = runningAtLeastBigSur ? titlebar.subviews[0] : nil;
     NSView* titlebarBackground = runningAtLeastBigSur ? titlebar.subviews[1] : nil;
 
@@ -1370,7 +1370,7 @@ AWT_ASSERT_APPKIT_THREAD;
     return (masks & NSWindowStyleMaskFullScreen) != 0;
 }
 
-- (void) disableTitlebar: (CGFloat) customHeaderHeight
+- (void) setTransparentTitlebarHeight: (CGFloat) customHeaderHeight
 {
     _customHeaderHeight = customHeaderHeight;
     dispatch_sync(dispatch_get_main_queue(), ^{
@@ -2238,7 +2238,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetTransparen
 
     NSWindow *nsWindow = (NSWindow *)jlong_to_ptr(windowPtr);
     AWTWindow *window = (AWTWindow*)[nsWindow delegate];
-    [window disableTitlebar:((CGFloat) customHeaderHeight)];
+    [window setTransparentTitlebarHeight:((CGFloat) customHeaderHeight)];
 
     JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1229,7 +1229,7 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
 
 - (CGFloat) getTransparentTitleBarButtonShrinkingFactor
 {
-    CGFloat minimumHeightWithoutShrinking = 28.0;
+    CGFloat minimumHeightWithoutShrinking = 28.0; // This is the smallest macOS title bar availabe with public APIs as of Monterey
     CGFloat shrinkingFactor = fmin(_transparentTitleBarHeight / minimumHeightWithoutShrinking, 1.0);
     return shrinkingFactor;
 }
@@ -1295,7 +1295,7 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
         [_transparentTitleBarButtonCenterXConstraints addObject:buttonCenterXConstraint];
         [newConstraints addObjectsFromArray:@[
             [button.widthAnchor constraintLessThanOrEqualToAnchor:titlebarContainer.heightAnchor multiplier:0.5],
-            // Those corrections are required because macOS adds a constant 2 px in resulting height to the buttons
+            // Those corrections are required to keep the icons perfectly round because macOS adds a constant 2 px in resulting height to their frame
             [button.heightAnchor constraintEqualToAnchor: button.widthAnchor multiplier:14.0/12.0 constant:-2.0],
             [button.centerYAnchor constraintEqualToAnchor:titlebarContainer.centerYAnchor],
             buttonCenterXConstraint,
@@ -1307,13 +1307,15 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
 
 - (void) updateTransparentTitleBarConstraints
 {
-    _transparentTitleBarHeightConstraint.constant = _transparentTitleBarHeight;
-    CGFloat shrinkingFactor = [self getTransparentTitleBarButtonShrinkingFactor];
-    CGFloat horizontalButtonOffset = shrinkingFactor * DefaultHorizontalTitleBarButtonOffset;
-    [_transparentTitleBarButtonCenterXConstraints enumerateObjectsUsingBlock:^(NSLayoutConstraint* buttonConstraint, NSUInteger index, BOOL *stop)
-    {
-        buttonConstraint.constant = (_transparentTitleBarHeight/2.0 + (index * horizontalButtonOffset));
-    }];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        _transparentTitleBarHeightConstraint.constant = _transparentTitleBarHeight;
+        CGFloat shrinkingFactor = [self getTransparentTitleBarButtonShrinkingFactor];
+        CGFloat horizontalButtonOffset = shrinkingFactor * DefaultHorizontalTitleBarButtonOffset;
+        [_transparentTitleBarButtonCenterXConstraints enumerateObjectsUsingBlock:^(NSLayoutConstraint* buttonConstraint, NSUInteger index, BOOL *stop)
+        {
+            buttonConstraint.constant = (_transparentTitleBarHeight/2.0 + (index * horizontalButtonOffset));
+        }];
+    });
 }
 
 - (void) resetTitleBar

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1272,7 +1272,7 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
     ]];
 
     AWTWindowDragView* windowDragView = [[AWTWindowDragView alloc] initWithPlatformWindow:self.javaPlatformWindow];
-    [titlebar addSubview:windowDragView];
+    [titlebar addSubview:windowDragView positioned:NSWindowBelow relativeTo:closeButtonView];
 
     for (NSView* view in @[titlebar, windowDragView])
     {

--- a/test/jdk/jb/java/awt/Window/MacNativeTransparentTitlebarWithCustomHeight.java
+++ b/test/jdk/jb/java/awt/Window/MacNativeTransparentTitlebarWithCustomHeight.java
@@ -27,7 +27,7 @@
  * @key headful
  * @summary [macosx] transparent titlebar with custom height test
  * @author Grigorii Kargin
- * @run main MacNativeTransparentTitlebarWithCustomHeight
+ * @run main MacNativeTransparentTitleBarWithCustomHeight
  * @requires (os.family == "mac")
  */
 
@@ -36,19 +36,19 @@ import java.awt.image.BufferedImage;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.*;
 
-public class MacNativeTransparentTitlebarWithCustomHeight
+public class MacNativeTransparentTitleBarWithCustomHeight
 {
     private static final int TD = 10;
     private static final Color darkSystemGray4 = new Color(58, 58, 60);
     private static final Color lightSystemGray6 = new Color(242, 242, 247);
-    static MacNativeTransparentTitlebarWithCustomHeight theTest;
+    static MacNativeTransparentTitleBarWithCustomHeight theTest;
     private Robot robot;
     private JFrame frame;
     private JRootPane rootPane;
 
     private int DELAY = 1000;
 
-    public MacNativeTransparentTitlebarWithCustomHeight() {
+    public MacNativeTransparentTitleBarWithCustomHeight() {
         try {
             robot = new Robot();
         } catch (AWTException ex) {
@@ -141,7 +141,7 @@ public class MacNativeTransparentTitlebarWithCustomHeight
         }
 
         try {
-            runSwing(() -> theTest = new MacNativeTransparentTitlebarWithCustomHeight());
+            runSwing(() -> theTest = new MacNativeTransparentTitleBarWithCustomHeight());
             theTest.performTest();
         } finally {
             if (theTest != null) {

--- a/test/jdk/jb/java/awt/Window/MacNativeTransparentTitlebarWithCustomHeight.java
+++ b/test/jdk/jb/java/awt/Window/MacNativeTransparentTitlebarWithCustomHeight.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key headful
+ * @summary [macosx] transparent titlebar with custom height test
+ * @author Grigorii Kargin
+ * @run main MacNativeTransparentTitlebarWithCustomHeight
+ * @requires (os.family == "mac")
+ */
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.*;
+
+public class MacNativeTransparentTitlebarWithCustomHeight
+{
+    private static final int TD = 10;
+    private static final Color darkSystemGray4 = new Color(58, 58, 60);
+    private static final Color lightSystemGray6 = new Color(242, 242, 247);
+    static MacNativeTransparentTitlebarWithCustomHeight theTest;
+    private Robot robot;
+    private JFrame frame;
+    private JRootPane rootPane;
+
+    private int DELAY = 1000;
+
+    public MacNativeTransparentTitlebarWithCustomHeight() {
+        try {
+            robot = new Robot();
+        } catch (AWTException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public void performTest() {
+
+        runSwing(() -> {
+            frame = new JFrame("");
+            frame.setBounds(100, 100, 300, 150);
+            rootPane = frame.getRootPane();
+            JComponent contentPane = (JComponent) frame.getContentPane();
+            JPanel comp = new JPanel();
+            contentPane.add(comp);
+            comp.setBackground(Color.RED);
+            frame.setVisible(true);
+        });
+
+        // check that titlebar is not of background color
+        for (int px = 140; px < 160; px++) {
+            for (int py = 5; py < 20; py++) {
+                Color c = getTestPixel(px, py);
+                if (validateColor(c, Color.RED)) {
+                    throw new RuntimeException("Test failed. Incorrect color " + c +
+                            "at (" + px + "," + py + ")");
+                }
+            }
+        }
+
+        robot.delay(DELAY);
+        runSwing(() -> rootPane.putClientProperty("apple.awt.windowTransparentTitleBarHeight", 42f));
+        robot.delay(DELAY);
+
+        // check that titlebar is of background color
+        for (int px = 140; px < 160; px++) {
+            for (int py = 5; py < 20; py++) {
+                Color c = getTestPixel(px, py);
+                if (!validateColor(c, Color.RED)) {
+                    throw new RuntimeException("Test failed. Incorrect color " + c +
+                            "at (" + px + "," + py + ")");
+                }
+            }
+        }
+
+        runSwing(() -> frame.dispose());
+
+        frame = null;
+        rootPane = null;
+    }
+
+    private Color getTestPixel(int x, int y) {
+        Rectangle bounds = frame.getBounds();
+        BufferedImage screenImage = robot.createScreenCapture(bounds);
+        int rgb = screenImage.getRGB(x, y);
+        int red = (rgb >> 16) & 0xFF;
+        int green = (rgb >> 8) & 0xFF;
+        int blue = rgb & 0xFF;
+        Color c = new Color(red, green, blue);
+        return c;
+    }
+
+    private boolean validateColor(Color c, Color expected) {
+        return Math.abs(c.getRed() - expected.getRed()) <= TD &&
+            Math.abs(c.getGreen() - expected.getGreen()) <= TD &&
+            Math.abs(c.getBlue() - expected.getBlue()) <= TD;
+    }
+
+    public void dispose() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+
+    private static void runSwing(Runnable r) {
+        try {
+            SwingUtilities.invokeAndWait(r);
+        } catch (InterruptedException e) {
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        if (!System.getProperty("os.name").contains("OS X")) {
+            System.out.println("This test is for MacOS only. Automatically passed on other platforms.");
+            return;
+        }
+
+        try {
+            runSwing(() -> theTest = new MacNativeTransparentTitlebarWithCustomHeight());
+            theTest.performTest();
+        } finally {
+            if (theTest != null) {
+                runSwing(() -> theTest.dispose());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi! 

In Fleet, we have a custom-painted title bar on macOS with non-default height. We had this logic implemented in Skiko, but recently we needed to add additional hit tests, so double click on buttons doesn't maximize the window. And we decided to move that to JBR to be consistent with our custom title bar implementation on Windows, which also uses JBR custom decorations and hit tests.