### PR TITLE
JBR-4107: A11y: macOS - wrong frame position if window is not on primary screen

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -768,7 +768,7 @@ static NSString* parentRole(NSAccessibilityRole nsRole)
 
     point.y += size.height;
     // Now make it into Cocoa screen coords.
-    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+    point.y = [[NSScreen screens][0] frame].size.height - point.y;
 
     return NSMakeRect(point.x, point.y, size.width, size.height);
 }
@@ -1085,7 +1085,7 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
                                  "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
 
     // Make it into java screen coords
-    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+    point.y = [[NSScreen screens][0] frame].size.height - point.y;
 
     jobject jparent = fComponent;
 


### PR DESCRIPTION
When application window is moved to another screen with different vertical resolution, a11y frames are placed into wrong position on screen. It looks like we are trying to transform coordinates using window main screen as an origin, but it should be a primary screen.