### PR TITLE
Tag AWT windows as sRGB surfaces

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -463,6 +463,9 @@ AWT_ASSERT_APPKIT_THREAD;
     if (self.nsWindow == nil) return nil; // no hope either
     [self.nsWindow release]; // the property retains the object already
 
+    // Tell the system we have an sRGB backing store
+    [self.nsWindow setColorSpace: [NSColorSpace sRGBColorSpace]];
+
     self.isEnabled = YES;
     self.isMinimizing = NO;
     self.javaPlatformWindow = platformWindow;


### PR DESCRIPTION
OSX assumes windows are in the display's color space by default.
Java2D assumes its output in sRGB, which means the sRGB colors
are interpreted by the OS as being in the display's color space.
This means that unless the display is set to use the sRGB color
space, the final result on screen will look incorrect.

Issue: http://issuetracker.google.com/208508346
Change-Id: Ie4c8dd2e41ba4f92db0c59e94825512ea93c6553