### PR TITLE
Fix view hierarchy restoration for full-screen mode on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
@@ -50,9 +50,6 @@
     NSWindowTabbingMode javaWindowTabbingMode;
     BOOL isEnterFullScreen;
     CGFloat _transparentTitleBarHeight;
-    id<NSObject> _windowWillEnterFullScreenNotification;
-    id<NSObject> _windowWillExitFullScreenNotification;
-    id<NSObject> _windowDidExitFullScreenNotification;
     NSMutableArray* _transparentTitleBarConstraints;
     NSLayoutConstraint *_transparentTitleBarHeightConstraint;
     NSMutableArray *_transparentTitleBarButtonCenterXConstraints;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1115,11 +1115,20 @@ AWT_ASSERT_APPKIT_THREAD;
     }
 }
 
+- (BOOL) isTransparentTitleBarEnabled
+{
+    return _transparentTitleBarHeight != 0.0;
+}
+
 - (void)windowWillEnterFullScreen:(NSNotification *)notification {
     [self fullScreenTransitionStarted];
     [self allowMovingChildrenBetweenSpaces:YES];
 
     self.isEnterFullScreen = YES;
+
+    if ([self isTransparentTitleBarEnabled]) {
+        [self resetTitleBar];
+    }
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CPLATFORM_WINDOW_CLASS();
@@ -1157,6 +1166,10 @@ AWT_ASSERT_APPKIT_THREAD;
 
     [self fullScreenTransitionStarted];
 
+    if ([self isTransparentTitleBarEnabled]) {
+        [self setWindowControlsHidden:YES];
+    }
+
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CPLATFORM_WINDOW_CLASS();
     DECLARE_METHOD(jm_windowWillExitFullScreen, jc_CPlatformWindow, "windowWillExitFullScreen", "()V");
@@ -1178,6 +1191,11 @@ AWT_ASSERT_APPKIT_THREAD;
     self.isEnterFullScreen = NO;
 
     [self fullScreenTransitionFinished];
+
+    if ([self isTransparentTitleBarEnabled]) {
+        [self setUpTransparentTitleBar];
+        [self setWindowControlsHidden:NO];
+    }
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
@@ -1408,62 +1426,35 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
     return (masks & NSWindowStyleMaskFullScreen) != 0;
 }
 
-- (void) configureWindowAndListenersForTransparentTitleBar
-{
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        [self.nsWindow setTitlebarAppearsTransparent:YES];
-        [self.nsWindow setTitleVisibility:NSWindowTitleHidden];
-        [self.nsWindow setStyleMask:[self.nsWindow styleMask]|NSWindowStyleMaskFullSizeContentView];
-
-        if (!self.isFullScreen) {
-            [self setUpTransparentTitleBar];
-        }
-    });
-    NSNotificationCenter* defaultCenter = [NSNotificationCenter defaultCenter];
-    NSOperationQueue* mainQueue = [NSOperationQueue mainQueue];
-    _windowWillEnterFullScreenNotification = [defaultCenter addObserverForName:NSWindowWillEnterFullScreenNotification object:self.nsWindow queue:mainQueue usingBlock:^(NSNotification* notification) {
-        [self resetTitleBar];
-    }];
-    _windowWillExitFullScreenNotification = [defaultCenter addObserverForName:NSWindowWillExitFullScreenNotification object:self.nsWindow queue:mainQueue usingBlock:^(NSNotification* notification) {
-        [self setWindowControlsHidden:YES];
-    }];
-    _windowDidExitFullScreenNotification = [defaultCenter addObserverForName:NSWindowDidExitFullScreenNotification object:self.nsWindow queue:mainQueue usingBlock:^(NSNotification* notification) {
-        [self setUpTransparentTitleBar];
-        [self setWindowControlsHidden:NO];
-    }];
-}
-
-- (void) configureWindowAndListenersForDefaultTitleBar
-{
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        [self.nsWindow setTitlebarAppearsTransparent:NO];
-        [self.nsWindow setTitleVisibility:NSWindowTitleVisible];
-        [self.nsWindow setStyleMask:[self.nsWindow styleMask]&(~NSWindowStyleMaskFullSizeContentView)];
-
-        if (!self.isFullScreen) {
-            [self resetTitleBar];
-        }
-    });
-    NSNotificationCenter* defaultCenter = [NSNotificationCenter defaultCenter];
-    [defaultCenter removeObserver:_windowWillEnterFullScreenNotification];
-    [defaultCenter removeObserver:_windowWillExitFullScreenNotification];
-    [defaultCenter removeObserver:_windowDidExitFullScreenNotification];
-    _windowWillEnterFullScreenNotification = _windowWillExitFullScreenNotification = _windowDidExitFullScreenNotification = nil;
-}
-
 - (void) setTransparentTitleBarHeight: (CGFloat) transparentTitleBarHeight
 {
     if (_transparentTitleBarHeight == transparentTitleBarHeight) return;
     if (_transparentTitleBarHeight != 0.0f) {
         _transparentTitleBarHeight = transparentTitleBarHeight;
         if (transparentTitleBarHeight == 0.0f) {
-            [self configureWindowAndListenersForDefaultTitleBar];
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                [self.nsWindow setTitlebarAppearsTransparent:NO];
+                [self.nsWindow setTitleVisibility:NSWindowTitleVisible];
+                [self.nsWindow setStyleMask:[self.nsWindow styleMask]&(~NSWindowStyleMaskFullSizeContentView)];
+
+                if (!self.isFullScreen) {
+                    [self resetTitleBar];
+                }
+            });
         } else if (_transparentTitleBarHeightConstraint != nil || _transparentTitleBarButtonCenterXConstraints != nil) {
             [self updateTransparentTitleBarConstraints];
         }
     } else {
         _transparentTitleBarHeight = transparentTitleBarHeight;
-        [self configureWindowAndListenersForTransparentTitleBar];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [self.nsWindow setTitlebarAppearsTransparent:YES];
+            [self.nsWindow setTitleVisibility:NSWindowTitleHidden];
+            [self.nsWindow setStyleMask:[self.nsWindow styleMask]|NSWindowStyleMaskFullSizeContentView];
+
+            if (!self.isFullScreen) {
+                [self setUpTransparentTitleBar];
+            }
+        });
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1318,7 +1318,8 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
     AWTWindowDragView* windowDragView = [[AWTWindowDragView alloc] initWithPlatformWindow:self.javaPlatformWindow];
     [titlebar addSubview:windowDragView positioned:NSWindowBelow relativeTo:closeButtonView];
 
-    for (NSView* view in @[titlebar, windowDragView])
+    NSArray* viewsToStretch = [titlebarContainer.subviews arrayByAddingObject:windowDragView];
+    for (NSView* view in viewsToStretch)
     {
         view.translatesAutoresizingMaskIntoConstraints = NO;
         [_transparentTitleBarConstraints addObjectsFromArray:@[
@@ -1329,12 +1330,16 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
         ]];
     }
 
+    for(NSView* view in titlebar.subviews)
+    {
+        view.translatesAutoresizingMaskIntoConstraints = NO;
+    }
+
     CGFloat shrinkingFactor = [self getTransparentTitleBarButtonShrinkingFactor];
     CGFloat horizontalButtonOffset = shrinkingFactor * DefaultHorizontalTitleBarButtonOffset;
     _transparentTitleBarButtonCenterXConstraints = [[NSMutableArray alloc] initWithCapacity:3];
     [@[closeButtonView, miniaturizeButtonView, zoomButtonView] enumerateObjectsUsingBlock:^(NSView* button, NSUInteger index, BOOL* stop)
     {
-        button.translatesAutoresizingMaskIntoConstraints = NO;
         NSLayoutConstraint* buttonCenterXConstraint = [button.centerXAnchor constraintEqualToAnchor:titlebarContainer.leftAnchor constant:(_transparentTitleBarHeight/2.0 + (index * horizontalButtonOffset))];
         [_transparentTitleBarButtonCenterXConstraints addObject:buttonCenterXConstraint];
         [_transparentTitleBarConstraints addObjectsFromArray:@[
@@ -1375,7 +1380,7 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
     [NSLayoutConstraint deactivateConstraints:_transparentTitleBarConstraints];
 
     AWTWindowDragView* windowDragView;
-    for (NSView* view in titlebar.subviews) {
+    for (NSView* view in [titlebar.subviews arrayByAddingObjectsFromArray:titlebarContainer.subviews]) {
         if ([view isMemberOfClass:[AWTWindowDragView class]]) {
             windowDragView = view;
         }


### PR DESCRIPTION
In the previous version of the code, we didn't correctly restore the translation of resize masks into constraints for the `titlebar` view, which mostly worked but had one edge case where it broke:
If the window already takes up the full width of the screen even before entering full-screen mode, then the constraints aren't updated correctly and there will be no window controls in the hidden title bar that appears when moving the mouse to the top of the screen.

See more details in this ticket: https://youtrack.jetbrains.com/issue/FL-11420/Exit-full-screen-buttons-disappears-in-full-screen-mode

I also merged the handlers for the transparent title bar into the existing full screen handlers - I must have missed those before.