### PR TITLE
Master17

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -978,6 +978,14 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         return ref.get();
     }
 
+    private boolean isTabbedWindow() {
+        AtomicBoolean ref = new AtomicBoolean();
+        execute(ptr -> {
+            ref.set(CWrapper.NSWindow.isTabbedWindow(ptr));
+        });
+        return ref.get();
+    }
+
     // We want a window to be always shown at the same space as its owning window.
     // But macOS doesn't have an API to control the target space for a window -
     // it's always shown at the active space. So if the target space isn't active now,
@@ -1345,7 +1353,9 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         // which is going to become 'main window', are placed above their siblings.
         CPlatformWindow rootOwner = getRootOwner();
         if (rootOwner.isVisible() && !rootOwner.isIconified() && !rootOwner.isActive()) {
-            rootOwner.execute(CWrapper.NSWindow::orderFrontIfOnActiveSpace);
+            if (rootOwner != this || !isTabbedWindow()) {
+                rootOwner.execute(CWrapper.NSWindow::orderFrontIfOnActiveSpace);
+            }
         }
 
         // Do not order child windows of iconified owner.

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CWrapper.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CWrapper.java
@@ -105,6 +105,8 @@ final class CWrapper {
         static native void zoom(long window);
 
         static native void makeFirstResponder(long window, long responder);
+        
+        static native boolean isTabbedWindow(long window);
     }
 
     static final class NSView {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
@@ -518,6 +518,31 @@ JNI_COCOA_EXIT(env);
 }
 
 /*
+ * Class:     sun_lwawt_macosx_CWrapper$NSWindow
+ * Method:    isTabbedWindow
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_sun_lwawt_macosx_CWrapper_00024NSWindow_isTabbedWindow
+(JNIEnv *env, jclass cls, jlong windowPtr)
+{
+    __block jboolean isTabbedWindow = JNI_FALSE;
+
+JNI_COCOA_ENTER(env);
+
+    if (@available(macOS 10.13, *)) {
+        NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
+        [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
+            isTabbedWindow = [[[window tabGroup] windows] count] > 1;
+        }];
+    }
+
+JNI_COCOA_EXIT(env);
+
+    return isTabbedWindow;
+}
+
+/*
  * Class:     sun_lwawt_macosx_CWrapper$NSView
  * Method:    addSubview
  * Signature: (JJ)V


### PR DESCRIPTION
For frame with several tabs when show only frame (without any dialogs and etc) do ignore `orderFront()' when frame activated. If user do click in inactive tab we have several `orderAboveSiblings()` and order front do cancel user choose.