### PR TITLE
Make bash scripts safer

### DIFF
--- a/jb/project/docker/mkdocker_aarch64.sh
+++ b/jb/project/docker/mkdocker_aarch64.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # This script creates a Docker image suitable for building AArch64 variant
 # of the JetBrains Runtime version 17.

--- a/jb/project/docker/mkdocker_musl_aarch64.sh
+++ b/jb/project/docker/mkdocker_musl_aarch64.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # This script creates a Docker image suitable for building musl AArch64 variant
 # of the JetBrains Runtime version 17.

--- a/jb/project/docker/mkdocker_musl_x64.sh
+++ b/jb/project/docker/mkdocker_musl_x64.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # This script creates a Docker image suitable for building musl-x64 variant
 # of the JetBrains Runtime version 17.

--- a/jb/project/tools/common/scripts/build-jbr-api.sh
+++ b/jb/project/tools/common/scripts/build-jbr-api.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 # $1 - Boot JDK
 # $2 - JBR part of API version

--- a/jb/project/tools/common/scripts/common.sh
+++ b/jb/project/tools/common/scripts/common.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 function do_maketest() {
   if [ "${bundle_type: -1}" == "t" ]; then

--- a/jb/project/tools/common/scripts/common.sh
+++ b/jb/project/tools/common/scripts/common.sh
@@ -3,13 +3,13 @@
 set -euo pipefail
 set -x
 
-function do_maketest() {
+function check_bundle_type_maketest() {
+  # check whether last char is 't', if so remove it
   if [ "${bundle_type: -1}" == "t" ]; then
-    echo ${bundle_type%?}
-    return 1
+    bundle_type="${bundle_type%?}"
+    do_maketest=1
   else
-    echo ${bundle_type}
-    return 0
+    do_maketest=0
   fi
 }
 
@@ -19,20 +19,23 @@ function getVersionProp() {
 
 while getopts ":i?" o; do
     case "${o}" in
-        i)
-            i="incremental build"
-            INC_BUILD=1
-            ;;
+        i) INC_BUILD=1 ;;
     esac
 done
 shift $((OPTIND-1))
 
+if [[ $# -lt 2 ]]; then
+  echo "Required at least two arguments: build_number bundle_type"
+  exit 1
+fi
+
 build_number=$1
 bundle_type=$2
-architecture=$3 # aarch64 or x64
+# shellcheck disable=SC2034
+architecture=${3:-x64} # aarch64 or x64
 
-bundle_type=$(do_maketest)
-do_maketest=$?
+check_bundle_type_maketest
+
 tag_prefix="jbr-"
 OPENJDK_TAG=$(git log --simplify-by-decoration --decorate=short --pretty=short | grep "$tag_prefix" | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ",")
 VERSION_FEATURE=$(getVersionProp "DEFAULT_VERSION_FEATURE")

--- a/jb/project/tools/linux/scripts/mkimages_aarch64.sh
+++ b/jb/project/tools/linux/scripts/mkimages_aarch64.sh
@@ -56,6 +56,7 @@ function create_image_bundle {
   __modules=$4
 
   libc_type_suffix=''
+  fastdebug_infix=''
 
   if is_musl; then libc_type_suffix='musl-' ; fi
 
@@ -111,7 +112,7 @@ case "$bundle_type" in
     ;;
 esac
 
-if [ -z "$INC_BUILD" ]; then
+if [ -z "${INC_BUILD:-}" ]; then
   do_configure || do_exit $?
   make clean CONF=$RELEASE_NAME || do_exit $?
 fi
@@ -131,6 +132,8 @@ if [ "$bundle_type" == "jcef" ] || [ "$bundle_type" == "fd" ]; then
   cp $JCEF_PATH/jmods/* $JSDK_MODS_DIR # $JSDK/jmods is not changed
 
   jbr_name_postfix="_${bundle_type}"
+else
+  jbr_name_postfix=""
 fi
 
 # create runtime image bundle

--- a/jb/project/tools/linux/scripts/mkimages_aarch64.sh
+++ b/jb/project/tools/linux/scripts/mkimages_aarch64.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   build_number - specifies the number of JetBrainsRuntime build

--- a/jb/project/tools/linux/scripts/mkimages_x64.sh
+++ b/jb/project/tools/linux/scripts/mkimages_x64.sh
@@ -56,6 +56,7 @@ function create_image_bundle {
   __modules=$4
 
   libc_type_suffix=''
+  fastdebug_infix=''
 
   if is_musl; then libc_type_suffix='musl-' ; fi
 
@@ -111,7 +112,7 @@ case "$bundle_type" in
     ;;
 esac
 
-if [ -z "$INC_BUILD" ]; then
+if [ -z "${INC_BUILD:-}" ]; then
   do_configure || do_exit $?
   make clean CONF=$RELEASE_NAME || do_exit $?
 fi
@@ -131,6 +132,8 @@ if [ "$bundle_type" == "jcef" ] || [ "$bundle_type" == "fd" ]; then
   cp $JCEF_PATH/jmods/* $JSDK_MODS_DIR # $JSDK/jmods is not changed
 
   jbr_name_postfix="_${bundle_type}"
+else
+  jbr_name_postfix=""
 fi
 
 # create runtime image bundle

--- a/jb/project/tools/linux/scripts/mkimages_x64.sh
+++ b/jb/project/tools/linux/scripts/mkimages_x64.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   build_number - specifies the number of JetBrainsRuntime build

--- a/jb/project/tools/linux/scripts/mkimages_x86.sh
+++ b/jb/project/tools/linux/scripts/mkimages_x86.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   JBSDK_VERSION    - specifies the current version of OpenJDK e.g. 11_0_6

--- a/jb/project/tools/mac/scripts/mkimages.sh
+++ b/jb/project/tools/mac/scripts/mkimages.sh
@@ -25,7 +25,6 @@ set -x
 source jb/project/tools/common/scripts/common.sh
 
 JCEF_PATH=${JCEF_PATH:=./jcef_mac}
-architecture=${architecture:=x64}
 BOOT_JDK=${BOOT_JDK:=$(/usr/libexec/java_home -v 16)}
 
 function do_configure {
@@ -76,11 +75,13 @@ function create_image_bundle {
   __modules_path=$3
   __modules=$4
 
+  fastdebug_infix=''
+
   tmp=.bundle.$$.tmp
   mkdir "$tmp" || do_exit $?
 
   [ "$bundle_type" == "fd" ] && [ "$__arch_name" == "$JBRSDK_BUNDLE" ] && __bundle_name=$__arch_name && fastdebug_infix="fastdebug-"
-  JBR=${__bundle_name}-${JBSDK_VERSION}-osx-${architecture}-${fastdebug_infix}b${build_number}
+  JBR=${__bundle_name}-${JBSDK_VERSION}-osx-${architecture}-${fastdebug_infix:-}b${build_number}
 
   JRE_CONTENTS=$tmp/$__arch_name/Contents
   mkdir -p "$JRE_CONTENTS" || do_exit $?
@@ -139,7 +140,7 @@ case "$bundle_type" in
     ;;
 esac
 
-if [ -z "$INC_BUILD" ]; then
+if [ -z "${INC_BUILD:-}" ]; then
   do_configure || do_exit $?
   make clean CONF=$RELEASE_NAME || do_exit $?
 fi
@@ -157,6 +158,8 @@ if [ "$bundle_type" == "jcef" ] || [ "$bundle_type" == "fd" ]; then
   cp $JCEF_PATH/jmods/* $JSDK_MODS_DIR # $JSDK/jmods is not changed
 
   jbr_name_postfix="_${bundle_type}"
+else
+  jbr_name_postfix=""
 fi
 
 # create runtime image bundle

--- a/jb/project/tools/mac/scripts/mkimages.sh
+++ b/jb/project/tools/mac/scripts/mkimages.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   build_number - specifies the number of JetBrainsRuntime build

--- a/jb/project/tools/mac/scripts/notarize.sh
+++ b/jb/project/tools/mac/scripts/notarize.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 APP_DIRECTORY=$1
 APPL_USER=$2

--- a/jb/project/tools/mac/scripts/sign.sh
+++ b/jb/project/tools/mac/scripts/sign.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 APPLICATION_PATH=$1
 APP_NAME=$2

--- a/jb/project/tools/mac/scripts/signapp.sh
+++ b/jb/project/tools/mac/scripts/signapp.sh
@@ -1,7 +1,8 @@
-#!/bin/bash -x
+#!/bin/bash
 
 #immediately exit script with an error if a command fails
 set -euo pipefail
+set -x
 
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
 export COPYFILE_DISABLE=true

--- a/jb/project/tools/test/check_jbr_size.sh
+++ b/jb/project/tools/test/check_jbr_size.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -euo pipefail
 
 while getopts ":t" o; do
     case "${o}" in

--- a/jb/project/tools/test/perfcmp.sh
+++ b/jb/project/tools/test/perfcmp.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 usage ()
 {

--- a/jb/project/tools/windows/scripts/mkimages_x64.sh
+++ b/jb/project/tools/windows/scripts/mkimages_x64.sh
@@ -48,6 +48,8 @@ function create_image_bundle {
   __modules_path=$3
   __modules=$4
 
+  fastdebug_infix=''
+
   [ "$bundle_type" == "fd" ] && [ "$__arch_name" == "$JBRSDK_BUNDLE" ] && __bundle_name=$__arch_name && fastdebug_infix="fastdebug-"
 
   echo Running jlink ...
@@ -82,7 +84,7 @@ case "$bundle_type" in
     ;;
 esac
 
-if [ -z "$INC_BUILD" ]; then
+if [ -z "${INC_BUILD:-}" ]; then
   do_configure || do_exit $?
   if [ $do_maketest -eq 1 ]; then
     make LOG=info CONF=$RELEASE_NAME clean images test-image || do_exit $?
@@ -108,6 +110,8 @@ if [ "$bundle_type" == "jcef" ] || [ "$bundle_type" == "fd" ]; then
   cp $JCEF_PATH/jmods/* ${JSDK_MODS_DIR} # $JSDK/jmods is not unchanged
 
   jbr_name_postfix="_${bundle_type}"
+else
+  jbr_name_postfix=""
 fi
 
 # create runtime image bundlef

--- a/jb/project/tools/windows/scripts/mkimages_x64.sh
+++ b/jb/project/tools/windows/scripts/mkimages_x64.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   build_number - specifies the number of JetBrainsRuntime build

--- a/jb/project/tools/windows/scripts/mkimages_x86.sh
+++ b/jb/project/tools/windows/scripts/mkimages_x86.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   JBSDK_VERSION    - specifies the current version of OpenJDK e.g. 11_0_6

--- a/jb/project/tools/windows/scripts/pack_x64.sh
+++ b/jb/project/tools/windows/scripts/pack_x64.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   build_number - specifies the number of JetBrainsRuntime build

--- a/jb/project/tools/windows/scripts/pack_x64.sh
+++ b/jb/project/tools/windows/scripts/pack_x64.sh
@@ -22,6 +22,8 @@ function pack_jbr {
   __bundle_name=$1
   __arch_name=$2
 
+  fastdebug_infix=''
+
   [ "$bundle_type" == "fd" ] && [ "$__arch_name" == "$JBRSDK_BUNDLE" ] && __bundle_name=$__arch_name && fastdebug_infix="fastdebug-"
   JBR=${__bundle_name}-${JBSDK_VERSION}-windows-x64-${fastdebug_infix}b${build_number}
 
@@ -39,6 +41,8 @@ BASE_DIR=.
 
 if [ "$bundle_type" == "jcef" ] || [ "$bundle_type" == "dcevm" ] || [ "$bundle_type" == "fd" ]; then
   jbr_name_postfix="_${bundle_type}"
+else
+  jbr_name_postfix=""
 fi
 
 pack_jbr jbr${jbr_name_postfix} jbr

--- a/jb/project/tools/windows/scripts/pack_x86.sh
+++ b/jb/project/tools/windows/scripts/pack_x86.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -x
+#!/bin/bash
+
+set -euo pipefail
+set -x
 
 # The following parameters must be specified:
 #   JBSDK_VERSION    - specifies the current version of OpenJDK e.g. 11_0_6


### PR DESCRIPTION
That would help detect build problems earlier than having empty artifacts like in https://youtrack.jetbrains.com/issue/JBR-4451