### PR TITLE
FL-11598 Fix accidental reset of window configuration on macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -78,7 +78,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class CPlatformWindow extends CFRetainedResource implements PlatformWindow {
-    private native long nativeCreateNSWindow(long nsViewPtr,long ownerPtr, long styleBits, double x, double y, double w, double h);
+    private native long nativeCreateNSWindow(long nsViewPtr,long ownerPtr, long styleBits, double x, double y, double w, double h, double transparentTitleBarHeight);
     private static native void nativeSetNSWindowStyleBits(long nsWindowPtr, int mask, int data);
     private static native void nativeSetNSWindowAppearance(long nsWindowPtr, String appearanceName);
     private static native void nativeSetNSWindowMenuBar(long nsWindowPtr, long menuBarPtr);
@@ -292,6 +292,10 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         new Property<CPlatformWindow>(WINDOW_TRANSPARENT_TITLE_BAR_HEIGHT) {
             public void applyProperty(final CPlatformWindow c, final Object value) {
                 if (value != null && (value instanceof Float)) {
+                    boolean enabled = (float) value != 0f;
+                    c.setStyleBits(FULL_WINDOW_CONTENT, enabled);
+                    c.setStyleBits(TRANSPARENT_TITLE_BAR, enabled);
+                    c.setStyleBits(TITLE_VISIBLE, !enabled);
                     c.execute(ptr -> AWTThreading.executeWaitToolkit(wait -> nativeSetTransparentTitleBarHeight(ptr, (float) value)));
                 }
             }
@@ -362,6 +366,8 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         responder = createPlatformResponder();
         contentView.initialize(peer, responder);
 
+        float transparentTitleBarHeight = getTransparentTitleBarHeight(_target);
+
         Rectangle bounds;
         if (!IS(DECORATED, styleBits)) {
             // For undecorated frames the move/resize event does not come if the frame is centered on the screen
@@ -382,7 +388,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                                 + ", bounds=" + bounds);
                     }
                     long windowPtr = createNSWindow(viewPtr, ownerPtr, styleBits,
-                            bounds.x, bounds.y, bounds.width, bounds.height);
+                            bounds.x, bounds.y, bounds.width, bounds.height, transparentTitleBarHeight);
                     if (logger.isLoggable(PlatformLogger.Level.FINE)) {
                         logger.fine("window created: " + Long.toHexString(windowPtr));
                     }
@@ -397,7 +403,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
                             + ", bounds=" + bounds);
                 }
                 long windowPtr = createNSWindow(viewPtr, 0, styleBits,
-                        bounds.x, bounds.y, bounds.width, bounds.height);
+                        bounds.x, bounds.y, bounds.width, bounds.height, transparentTitleBarHeight);
                 if (logger.isLoggable(PlatformLogger.Level.FINE)) {
                     logger.fine("window created: " + Long.toHexString(windowPtr));
                 }
@@ -558,6 +564,14 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
             prop = rootpane.getClientProperty(WINDOW_TITLE_VISIBLE);
             if (prop != null) {
                 styleBits = SET(styleBits, TITLE_VISIBLE, Boolean.parseBoolean(prop.toString()));
+            }
+
+            prop = rootpane.getClientProperty(WINDOW_TRANSPARENT_TITLE_BAR_HEIGHT);
+            if (prop != null) {
+                boolean enabled = Float.parseFloat(prop.toString()) != 0f;
+                styleBits = SET(styleBits, FULL_WINDOW_CONTENT, enabled);
+                styleBits = SET(styleBits, TRANSPARENT_TITLE_BAR, enabled);
+                styleBits = SET(styleBits, TITLE_VISIBLE, !enabled);
             }
         }
 
@@ -1437,8 +1451,16 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         return false;
     }
 
-    private long createNSWindow(long nsViewPtr,long ownerPtr, long styleBits, double x, double y, double w, double h) {
-        return AWTThreading.executeWaitToolkit(() -> nativeCreateNSWindow(nsViewPtr, ownerPtr, styleBits, x, y, w, h));
+    private long createNSWindow(long nsViewPtr,
+                                long ownerPtr,
+                                long styleBits,
+                                double x,
+                                double y,
+                                double w,
+                                double h,
+                                double transparentTitleBarHeight) {
+        return AWTThreading.executeWaitToolkit(() ->
+                nativeCreateNSWindow(nsViewPtr, ownerPtr, styleBits, x, y, w, h, transparentTitleBarHeight));
     }
 
     // ----------------------------------------------------------------------
@@ -1472,20 +1494,24 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
         isFullScreenAnimationOn = false;
     }
 
-    // JBR API internals
-    private static void setCustomDecorationTitleBarHeight(Window target, ComponentPeer peer, float height) {
-        if (peer instanceof LWComponentPeer) {
-            PlatformWindow platformWindow = ((LWComponentPeer<?, ?>) peer).getPlatformWindow();
-            if (platformWindow instanceof CPlatformWindow) {
-                ((CPlatformWindow) platformWindow).execute(ptr -> {
-                    AWTThreading.executeWaitToolkit(wait -> nativeSetTransparentTitleBarHeight(ptr, height));
-                });
-                if (target instanceof javax.swing.RootPaneContainer) {
-                    final javax.swing.JRootPane rootpane = ((javax.swing.RootPaneContainer)target).getRootPane();
-                    if (rootpane != null) rootpane.putClientProperty(WINDOW_TRANSPARENT_TITLE_BAR_HEIGHT, height);
+    private float getTransparentTitleBarHeight(Window target) {
+        if (target instanceof javax.swing.RootPaneContainer) {
+            final javax.swing.JRootPane rootpane = ((javax.swing.RootPaneContainer)target).getRootPane();
+            if (rootpane != null) {
+                Object transparentTitleBarHeightProperty = rootpane.getClientProperty(WINDOW_TRANSPARENT_TITLE_BAR_HEIGHT);
+                if (transparentTitleBarHeightProperty != null) {
+                    return Float.parseFloat(transparentTitleBarHeightProperty.toString());
                 }
             }
         }
+        return 0f;
     }
 
+    // JBR API internals
+    private static void setCustomDecorationTitleBarHeight(Window target, ComponentPeer peer, float height) {
+        if (target instanceof javax.swing.RootPaneContainer) {
+            final javax.swing.JRootPane rootpane = ((javax.swing.RootPaneContainer)target).getRootPane();
+            if (rootpane != null) rootpane.putClientProperty(WINDOW_TRANSPARENT_TITLE_BAR_HEIGHT, height);
+        }
+    }
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -416,7 +416,7 @@ AWT_NS_WINDOW_IMPLEMENTATION
     }
 
     if (IS(mask, TITLE_VISIBLE) && [self.nsWindow respondsToSelector:@selector(setTitleVisibility:)]) {
-        [self.nsWindow setTitleVisibility:(IS(bits, TITLE_VISIBLE)) ? NSWindowTitleVisible :NSWindowTitleHidden];
+        [self.nsWindow setTitleVisibility:(IS(bits, TITLE_VISIBLE) ? NSWindowTitleVisible : NSWindowTitleHidden)];
     }
 
 }
@@ -426,6 +426,7 @@ AWT_NS_WINDOW_IMPLEMENTATION
                     styleBits:(jint)bits
                     frameRect:(NSRect)rect
                   contentView:(NSView *)view
+    transparentTitleBarHeight:(CGFloat)transparentTitleBarHeight
 {
 AWT_ASSERT_APPKIT_THREAD;
 
@@ -485,6 +486,11 @@ AWT_ASSERT_APPKIT_THREAD;
     self.javaWindowTabbingMode = [self getJavaWindowTabbingMode];
     self.nsWindow.collectionBehavior = NSWindowCollectionBehaviorManaged;
     self.isEnterFullScreen = NO;
+
+    _transparentTitleBarHeight = transparentTitleBarHeight;
+    if (transparentTitleBarHeight != 0.0 && !self.isFullScreen) {
+        [self setUpTransparentTitleBar];
+    }
 
     return self;
 }
@@ -1429,32 +1435,25 @@ static const CGFloat DefaultHorizontalTitleBarButtonOffset = 20.0;
 - (void) setTransparentTitleBarHeight: (CGFloat) transparentTitleBarHeight
 {
     if (_transparentTitleBarHeight == transparentTitleBarHeight) return;
+
     if (_transparentTitleBarHeight != 0.0f) {
         _transparentTitleBarHeight = transparentTitleBarHeight;
         if (transparentTitleBarHeight == 0.0f) {
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                [self.nsWindow setTitlebarAppearsTransparent:NO];
-                [self.nsWindow setTitleVisibility:NSWindowTitleVisible];
-                [self.nsWindow setStyleMask:[self.nsWindow styleMask]&(~NSWindowStyleMaskFullSizeContentView)];
-
-                if (!self.isFullScreen) {
+            if (!self.isFullScreen) {
+                dispatch_sync(dispatch_get_main_queue(), ^{
                     [self resetTitleBar];
-                }
-            });
+                });
+            }
         } else if (_transparentTitleBarHeightConstraint != nil || _transparentTitleBarButtonCenterXConstraints != nil) {
             [self updateTransparentTitleBarConstraints];
         }
     } else {
         _transparentTitleBarHeight = transparentTitleBarHeight;
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            [self.nsWindow setTitlebarAppearsTransparent:YES];
-            [self.nsWindow setTitleVisibility:NSWindowTitleHidden];
-            [self.nsWindow setStyleMask:[self.nsWindow styleMask]|NSWindowStyleMaskFullSizeContentView];
-
-            if (!self.isFullScreen) {
+        if (!self.isFullScreen) {
+            dispatch_sync(dispatch_get_main_queue(), ^{
                 [self setUpTransparentTitleBar];
-            }
-        });
+            });
+        }
     }
 }
 
@@ -1570,10 +1569,10 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetAllowAutom
 /*
  * Class:     sun_lwawt_macosx_CPlatformWindow
  * Method:    nativeCreateNSWindow
- * Signature: (JJIIII)J
+ * Signature: (JJIDDDDD)J
  */
 JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeCreateNSWindow
-(JNIEnv *env, jobject obj, jlong contentViewPtr, jlong ownerPtr, jlong styleBits, jdouble x, jdouble y, jdouble w, jdouble h)
+(JNIEnv *env, jobject obj, jlong contentViewPtr, jlong ownerPtr, jlong styleBits, jdouble x, jdouble y, jdouble w, jdouble h, jdouble transparentTitleBarHeight)
 {
     __block AWTWindow *window = nil;
 
@@ -1600,7 +1599,8 @@ JNI_COCOA_ENTER(env);
                                                ownerWindow:owner
                                                  styleBits:styleBits
                                                  frameRect:frameRect
-                                               contentView:contentView];
+                                               contentView:contentView
+                                 transparentTitleBarHeight:(CGFloat)transparentTitleBarHeight];
         // the window is released is CPlatformWindow.nativeDispose()
 
         if (window) {
@@ -1692,8 +1692,8 @@ JNI_COCOA_EXIT(env);
 
 /*
  * Class:     sun_lwawt_macosx_CPlatformWindow
- * Method:    nativeSetNSWindowStyleBits
- * Signature: (JII)V
+ * Method:    nativeSetNSWindowAppearance
+ * Signature: (JLjava/lang/String;)V
  */
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowAppearance
         (JNIEnv *env, jclass clazz, jlong windowPtr,  jstring appearanceName)


### PR DESCRIPTION
This also aligns the handling of the style mask with how the other settings are applied: It uses a client property now.

The property is now also applied directly on peer initialization so that there is no need to re-apply, and the window directly appears in the correct configuration.

The issue that previously occurred was that enabling custom window decoration through the JBR API wasn't enough to keep it reliably there. It would reset everytime we applied style bits again because the internal stored style bits didn't contain the correct configuration regarding `WINDOW_FULL_CONTENT`, `WINDOW_TITLE_VISIBLE`, and `WINDOW_TRANSPARENT_TITLE_BAR`. This lead to the behavior as seen in the recording.

With these changes, the custom window decoration is now correctly applied through a custom property and thus also stored in the internal style bits.

https://user-images.githubusercontent.com/4516798/172323054-d701d6a1-cc52-46ea-8d26-aea402a2bcef.mov
