### PR TITLE
Backport JDK-8280476 fix

### DIFF
--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -129,6 +129,16 @@ static inline uint32_t uimm(uint32_t val, int hi, int lo)
 
 uint64_t replicate(uint64_t bits, int nbits, int count)
 {
+  assert(count > 0, "must be");
+  assert(nbits > 0, "must be");
+  assert(count * nbits <= 64, "must be");
+
+  // Special case nbits == 64 since the shift below with that nbits value
+  // would result in undefined behavior.
+  if (nbits == 64) {
+    return bits;
+  }
+
   uint64_t result = 0;
   // nbits may be 64 in which case we want mask to be -1
   uint64_t mask = ones(nbits);
@@ -363,4 +373,3 @@ uint32_t encoding_for_fp_immediate(float immediate)
   res = (s << 7) | (r << 4) | f;
   return res;
 }
-


### PR DESCRIPTION
This bug (https://bugs.openjdk.org/browse/JDK-8280476) is triggered when building against Xcode 13.3. I see the exact same error message and realized that this [commit](https://github.com/openjdk/jdk17u-dev/commit/fbe05ec561e8d2a061be126c969c37c219b594f3) needed to be added.

During or after building the image, I see:

```
/Users/rogerh/Development/JetBrainsRuntime/build/macosx-aarch64-server-release/jdk/bin/java --version
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (assembler_aarch64.hpp:248), pid=63683, tid=9475
#  guarantee(val < (1ULL << nbits)) failed: Field too big for insn
#
# JRE version:  (17.0.5) (build )
# Java VM: OpenJDK 64-Bit Server VM (17.0.5-internal+0-adhoc.rogerh.JetBrainsRuntime, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, bsd-aarch64)
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/rogerh/Development/JetBrainsRuntime/build/macosx-aarch64-server-release/make-support/failure-logs/hs_err_pid63683.log
#

```

There are also sprintf error warnings that I was able to suppress to get things to compile with Xcode 13:

```
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -58,6 +58,8 @@ ifeq ($(call check-jvm-feature, compiler2), true)
 
   ADLC_CFLAGS += -I$(TOPDIR)/src/hotspot/share
 
+  ADLC_CFLAGS += -Wno-deprecated-declarations
+
   # Add file macro mappings
   ADLC_CFLAGS += $(FILE_MACRO_CFLAGS)

```

Along with passing in `--with-extra-cxxflags="-Wno-deprecated-declarations"` when running the configure script.