### PR TITLE
JBR-6124 Fix macOS services writing text back to textfield

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -850,7 +850,7 @@ static void debugPrintNSEvent(NSEvent* event, const char* comment) {
 - (BOOL)replaceAccessibleTextSelection:(NSString *)text
 {
     id focused = [self accessibilityFocusedUIElement];
-    if (![focused respondsToSelector:@selector(setAccessibilitySelectedText)]) return NO;
+    if (![focused respondsToSelector:@selector(setAccessibilitySelectedText:)]) return NO;
     [focused setAccessibilitySelectedText:text];
     return YES;
 }


### PR DESCRIPTION
in place of #245 

https://en.wikipedia.org/wiki/Services_menu
Fix macOS menu services not being able to write text back to textfield due to the mismatch of ObjectiveC method signature.

`@selector(setAccessibilitySelectedText)` never selects the desired method `- (void)setAccessibilitySelectedText:(NSString *)accessibilitySelectedText` for lack of the parameter mark (a colon).