### PR TITLE
JBR-6194 Fix VoiceOver reading old JComboBox value after changing it

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -60,6 +60,7 @@ import javax.accessibility.AccessibleTable;
 import javax.accessibility.AccessibleText;
 import javax.accessibility.AccessibleValue;
 import javax.swing.Icon;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;
@@ -1160,6 +1161,20 @@ class CAccessibility implements PropertyChangeListener {
         return invokeAndWait(() -> {
             AccessibleContext ac = a.getAccessibleContext();
             return ac == null ? null : AccessibleComponentAccessor.getAccessible(ac);
+        }, c);
+    }
+
+    private static boolean isComboBoxEditable(Accessible a, Component c) {
+        if (a == null) return false;
+
+        return invokeAndWait(new Callable<Boolean>() {
+            public Boolean call() throws Exception {
+                Accessible sa = CAccessible.getSwingAccessible(a);
+                if (sa instanceof JComboBox<?> comboBox) {
+                    return comboBox.isEditable();
+                }
+                return false;
+            }
         }, c);
     }
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ComboBoxAccessibility.m
@@ -57,6 +57,18 @@ GET_CACCESSIBILITY_CLASS_RETURN(nil);
     return value;
 }
 
+- (BOOL)isEditable
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(NO);
+    DECLARE_STATIC_METHOD_RETURN(sjm_isComboBoxEditable, sjc_CAccessibility, "isComboBoxEditable", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", NO);
+
+    BOOL isEditable = (*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, sjm_isComboBoxEditable, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+
+    return isEditable;
+}
+
 // NSAccessibilityElement protocol methods
 
 - (id)accessibilityValue
@@ -66,17 +78,22 @@ GET_CACCESSIBILITY_CLASS_RETURN(nil);
     if (expanded) {
         return nil;
     }
-    if (!expanded &&
-        (value == nil)) {
-        [self accessibleSelection];
-    }
 
-    return [value accessibilityLabel];
+    [self accessibleSelection];
+
+    return value != nil ? [value accessibilityLabel] : nil;
 }
 
 - (NSArray *)accessibilitySelectedChildren
 {
     return [NSArray arrayWithObject:[self accessibleSelection]];
+}
+
+- (NSAccessibilityRole)accessibilityRole
+{
+    return [self isEditable]
+           ? NSAccessibilityComboBoxRole
+           : NSAccessibilityPopUpButtonRole;
 }
 
 - (void)dealloc

--- a/test/jdk/java/awt/a11y/AccessibleJComboBoxVoiceOverTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJComboBoxVoiceOverTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test for VoiceOver-specific issues of JComboBox
+ * @author dmitry.drobotov@jetbrains.com
+ * @run main/manual AccessibleJComboBoxVoiceOverTest
+ * @requires (os.family == "mac")
+ */
+
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import java.awt.FlowLayout;
+import java.util.concurrent.CountDownLatch;
+
+public class AccessibleJComboBoxVoiceOverTest extends AccessibleComponentTest {
+
+    @java.lang.Override
+    public CountDownLatch createCountDownLatch() {
+        return new CountDownLatch(1);
+    }
+
+    void createCombobox() {
+        INSTRUCTIONS = """
+                INSTRUCTIONS:
+                Check VoiceOver-specific issues of JComboBox.
+
+                Turn VoiceOver on, and Tab to the combo box.
+
+                Use VO+Space shortcut to open the combo box and select a new item.
+                Move keyboard focus away from the combo box using Shift+Tab and then back to the combo box by Tab.
+                Repeat the same step with VoiceOver cursor navigation using VO+Left and VO+Right.
+
+                If in both cases VoiceOver reads the newly selected value, press PASS, otherwise press FAIL.""";
+
+        JPanel frame = new JPanel();
+
+        String[] NAMES = {"One", "Two", "Three", "Four", "Five"};
+        JComboBox<String> combo = new JComboBox<>(NAMES);
+
+        JLabel label = new JLabel("This is combobox:");
+        label.setLabelFor(combo);
+
+        frame.setLayout(new FlowLayout());
+        frame.add(label);
+        frame.add(combo);
+        exceptionString = "AccessibleJComboBoxVoiceOver test failed!";
+        super.createUI(frame, "AccessibleJComboBoxVoiceOverTest");
+    }
+
+    public static void main(String[] args) throws Exception {
+        AccessibleJComboBoxVoiceOverTest test = new AccessibleJComboBoxVoiceOverTest();
+
+        countDownLatch = test.createCountDownLatch();
+        SwingUtilities.invokeLater(test::createCombobox);
+        countDownLatch.await();
+
+        if (!testResult) {
+            throw new RuntimeException(a11yTest.exceptionString);
+        }
+    }
+}


### PR DESCRIPTION
### Changes

* Removed `(value == nil)` check in `ComboBoxAccessibility`. With this check, the value was not reassigned on every get request of `accessibilityValue`, but only on get `accessibilitySelectedChildren`. When changing focus by Tab, only get `accessibilityValue` is called, and because `value` is already not nil, the old value was returned. 
    * Even with this check removed, VoiceOver still reads the old value when moving VO cursor from and to the combo box (for example using VO+Left and VO+Right shortcuts). I couldn't find the reason why it happens, but it's possible that when working with a "combo box", VoiceOver expects that there is a text field, and listens to text update events, but in case of non-editable combo box, there is no text field.
* Changed role to `NSAccessibilityPopUpButtonRole` if combo box is not editable. This fixes the bug with not updated value when using VO cursor navigation. Additional reasoning for using "popup button" role:
    * Native MacOS non-editable combo boxes and non-editable HTML `<select>` elements also have the "popup button" role instead of "combo box", so the role should become more clear.
    * With "combo box" role, VoiceOver was saying "Type text, or to display a list of choices, press Control-Option-Space". In case of non-editable combo box, there is no text field, so "type text" instruction was misleading. Now it says only "To display a list of options, press Control-Option-Space".
    * With "popup button" role, shortcut VO+Space to open the combo box menu works correctly.
    
    
### Testing

Tested the fix in SwingSet demo app and in a separate test app (based on AccessibleJComboboxTest but with VoiceOver-specific instructions).

#### Before

SwingSet:

https://github.com/JetBrains/JetBrainsRuntime/assets/102954094/cb59b6f0-4486-4439-a486-04470bf613d8

Test case app:

https://github.com/JetBrains/JetBrainsRuntime/assets/102954094/e606b026-0f08-4b5e-88ee-9b4ea0729e5b

#### After

SwingSet:

https://github.com/JetBrains/JetBrainsRuntime/assets/102954094/e224afd4-c63b-4e2a-a4e7-7b579afdc671


Test case app:

https://github.com/JetBrains/JetBrainsRuntime/assets/102954094/3440492a-9b80-4c6d-9b06-bcdaaf06e054


Additionally tested in IntelliJ with JBR including this fix, the issue [IDEA-317420](https://youtrack.jetbrains.com/issue/IDEA-317420/Accessibility-Voice-Over-on-macOS-reads-old-FontComboBox-value-after-change) is fixed.

