### PR TITLE
JBR-4479 Add text caret tracking for macOS Accessibility Zoom

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -87,6 +87,7 @@ class CAccessible extends CFRetainedResource implements Accessible {
     private static native void treeNodeCollapsed(long ptr);
     private static native void selectedCellsChanged(long ptr);
     private static native void tableContentCacheClear(long ptr);
+    private static native void updateZoomCaretFocus(long ptr);
 
     private Accessible accessible;
 
@@ -132,6 +133,8 @@ class CAccessible extends CFRetainedResource implements Accessible {
                 Object oldValue = e.getOldValue();
                 if (name.equals(ACCESSIBLE_CARET_PROPERTY)) {
                     execute(ptr -> selectedTextChanged(ptr));
+                    // Notify macOS Accessibility Zoom to move focus to the new caret location.
+                    execute(ptr -> updateZoomCaretFocus(ptr));
                 } else if (name.equals(ACCESSIBLE_TEXT_PROPERTY)) {
                     execute(ptr -> valueChanged(ptr));
                 } else if (name.equals(ACCESSIBLE_SELECTION_PROPERTY)) {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibleText.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibleText.java
@@ -29,6 +29,7 @@ import java.awt.Component;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
+import java.awt.im.InputMethodRequests;
 import java.util.concurrent.Callable;
 
 import javax.accessibility.Accessible;
@@ -342,5 +343,34 @@ class CAccessibleText {
         if (line == null) return null;
 
         return new int[] { line.getStartOffset(), line.getEndOffset() };
+    }
+
+    static double[] getCaretRectangle(final Accessible a, final Component c) {
+        final double[] ret = new double[4];
+
+        if (a == null) return null;
+
+        return CAccessibility.invokeAndWait(new Callable<double[]>() {
+            public double[] call() throws Exception {
+                final Accessible sa = CAccessible.getSwingAccessible(a);
+                if (!(sa instanceof Component)) return null;
+
+                final Component component = (Component) sa;
+
+                final InputMethodRequests imr = component.getInputMethodRequests();
+                if (imr == null) return null;
+
+                final Rectangle caretRectangle = imr.getTextLocation(null);
+
+                if (caretRectangle == null) return null;
+
+                ret[0] = caretRectangle.getX();
+                ret[1] = caretRectangle.getY();
+                ret[2] = 1; // Use 1 as caret width.
+                ret[3] = caretRectangle.getHeight();
+
+                return ret;
+            }
+        }, c);
     }
 }


### PR DESCRIPTION
Added a call to [UAZoomChangeFocus](https://developer.apple.com/documentation/applicationservices/1458830-uazoomchangefocus?changes=_3&language=objc) function when a text component fires an `ACCESSIBLE_CARET_PROPERTY` changed event. `InputMethodRequests.getTextLocation` is used to get the caret location.

How it works in IDEA and SwingSet (video quality is not great due to GitHub limits):

https://github.com/JetBrains/JetBrainsRuntime/assets/102954094/4590f056-9b00-4b7f-b735-1de51ee9c6f6

https://github.com/JetBrains/JetBrainsRuntime/assets/102954094/4670baab-ae63-4f80-967d-e6dd9ab4426c

### Known issues and further plans
* There are a few cases when zoom doesn't follow caret in the Editor component in IntelliJ: when deleting text, pasting text, adding/removing tab indentation, using page up/down keys, and there may be more. Some of it is caused by the lack of caret change event, which we can implement as follow-up work later, while for other cases, it doesn't seem to work anywhere (e.g. Safari, Chrome, TextEdit).
* Caret tracking works by moving the mouse pointer to the middle of the screen, which can block a part of the text, especially if the pointer size is big. Other apps are actually hiding the pointer when typing or navigating the text, but IntelliJ only hides it when typing (https://youtrack.jetbrains.com/issue/IDEA-69397). We should consider additionally implementing hiding the cursor when moving the caret, not just on typing.
* Ideally, the Zoom should follow all keyboard focus changes, not only the text caret (if it's enabled in Zoom settings), which can be implemented by using the same `UAZoomChangeFocus` function. I decided to work on this part later in a separate PR, as it seems to be a bigger effort, and the text caret tracking alone brings a lot of value for IDE users.
