### PR TITLE
JBR-6472 Add default value in CAccessibility.isComboBoxEditable to avoid NPE

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -1175,6 +1175,6 @@ class CAccessibility implements PropertyChangeListener {
                 }
                 return false;
             }
-        }, c);
+        }, c, false);
     }
 }


### PR DESCRIPTION
`CAccessibility.invokeAndWait` can return null if no default value is specified, so in this case we'll get  `java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "sun.lwawt.macosx.CAccessibility.invokeAndWait(java.util.concurrent.Callable, java.awt.Component)" is null`. 

With the `false` default value `invokeAndWait` will never return null.