### PR TITLE
JBR-6593 Fix UI freezes with JAWS announcements

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/AccessibleAnnouncer/JawsAnnouncer.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/AccessibleAnnouncer/JawsAnnouncer.cpp
@@ -31,7 +31,6 @@
 #include "sun_swing_AccessibleAnnouncer.h"
 #include "jni_util.h"                           // JNU_ThrowOutOfMemoryError
 #include "debug_assert.h"                       // DASSERT
-#include <windows.h>                            // GetCurrentThreadId
 #include <initguid.h>                           // DEFINE_GUID
 
 
@@ -57,7 +56,7 @@ public: // assignments
 public:
     HRESULT tryInitialize() {
         if (!isInitialized()) {
-            m_initializeResult = CoInitialize(nullptr);
+            m_initializeResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
         }
         return m_initializeResult;
     }
@@ -109,17 +108,7 @@ bool JawsAnnounce(JNIEnv *env, jstring str, jint priority)
     DASSERT(env != nullptr);
     DASSERT(str != nullptr);
 
-    static const DWORD comInitThreadId = ::GetCurrentThreadId();
-
-    const DWORD currThread = ::GetCurrentThreadId();
-    if (currThread != comInitThreadId) {
-#ifdef DEBUG
-        fprintf(stderr, "JawsAnnounce: currThread != comInitThreadId.\n");
-#endif
-        return false;
-    }
-
-    static ComInitializationWrapper comInitializer;
+    ComInitializationWrapper comInitializer;
     comInitializer.tryInitialize();
     if (!comInitializer.isInitialized()) {
 #ifdef DEBUG


### PR DESCRIPTION
* Execute `AccessibleAnnouncer.nativeAnnounce` on a background thread on Windows to fix UI freezes. IntelliJ calls this method from EDT, but it doesn't need to run on EDT because on Windows it simply calls screen readers API without interacting with UI components. Additionally, when using a background thread, the JAWS `SayString` method, which previously could have been running for multiple seconds, is now executed immediately as expected, but the root cause of previous delays is unclear.
* In `JawsAnnouncer`, initialize COM library with the multithreaded model to allow executing it from different threads. By making `comInitializer` non-static, now COM is initialized and uninitialized on every call of the method as required by the [documentation](https://learn.microsoft.com/en-us/windows/win32/learnwin32/initializing-the-com-library): "Each thread that uses a COM interface must make a separate call to this function. For every successful call to CoInitializeEx, you must call CoUninitialize before the thread exits". The `IJawsApi` COM object is still static and reused by different threads, which is allowed with a multithreaded concurrency model. It shouldn't cause issues because it has no state and only forwards calls to JAWS.

Tested on jbr17, jbr21 and main.