### PR TITLE
JBR-6547 WLToolkit: no app icon in GNOME

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -62,8 +62,6 @@ public class WLComponentPeer implements ComponentPeer {
     private static final PlatformLogger focusLog = PlatformLogger.getLogger("sun.awt.wl.focus.WLComponentPeer");
     private static final PlatformLogger popupLog = PlatformLogger.getLogger("sun.awt.wl.popup.WLComponentPeer");
 
-    private static final String appID = System.getProperty("sun.java.command");
-
     // mapping of AWT cursor types to X cursor names
     // multiple variants can be specified, that will be tried in order
     private static final String[][] CURSOR_NAMES = {
@@ -282,7 +280,7 @@ public class WLComponentPeer implements ComponentPeer {
                             getParentNativePtr(target),
                             target.getX(), target.getY(),
                             isModal, isMaximized, isMinimized,
-                            title, appID);
+                            title, WLToolkit.getApplicationID());
                 }
                 final long wlSurfacePtr = getWLSurface(nativePtr);
                 WLToolkit.registerWLSurface(wlSurfacePtr, this);

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLToolkit.java
@@ -185,6 +185,14 @@ public class WLToolkit extends UNIXToolkit implements Runnable {
         System.setProperty(extraButtons, String.valueOf(areExtraMouseButtonsEnabled));
     }
 
+    static String getApplicationID() {
+        // Do not cache the properties as the application might want to change
+        // them at run time. Might also consider using JComponent's client property
+        // for per-window app ID
+        String appID = System.getProperty("awt.app.id");
+        return appID != null ? appID : System.getProperty("sun.java.command");
+    }
+
     public static boolean isToolkitThread() {
         return Thread.currentThread() == toolkitThread;
     }

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLWindowPeer.java
@@ -143,7 +143,7 @@ public class WLWindowPeer extends WLComponentPeer implements WindowPeer {
 
     @Override
     public void updateIconImages() {
-
+        // No support for this from Wayland, icon is a desktop integration feature.
     }
 
     @Override


### PR DESCRIPTION
Allow to associate the application's window with .desktop file with icon and other info with -Dawt.app.id=... (DBus application name similar to WM_CLASS in X