### PR TITLE
JBR-6598 Wayland: window gets un-maximized after switching

### DIFF
--- a/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.c
+++ b/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.c
@@ -58,6 +58,9 @@ static void
 ScheduleFrameCallback(WLSurfaceBufferManager * manager);
 
 static void
+CancelFrameCallback(WLSurfaceBufferManager * manager);
+
+static void
 CopyDrawBufferToShowBuffer(WLSurfaceBufferManager * manager);
 
 static void
@@ -581,6 +584,11 @@ ShowBufferInvalidateForNewSize(WLSurfaceBufferManager * manager)
         assert(buffer->next == NULL);
         SurfaceBufferDestroy(buffer);
         manager->bufferForShow.wlSurfaceBuffer = NULL;
+        // Even though technically we didn't detach the buffer from the surface,
+        // we need to attach a new, resized one as soon as possible. If we wait
+        // for the next frame event to do that, Mutter may not remember
+        // the latest size of the window.
+        manager->isBufferAttached = false;
     }
 
     while (manager->buffersFree) {
@@ -593,6 +601,11 @@ ShowBufferInvalidateForNewSize(WLSurfaceBufferManager * manager)
     // as soon as they are released (see wl_buffer_release()).
 
     ShowBufferCreate(manager);
+
+    // Need to wait for WLSBM_SurfaceCommit() with the new content for
+    // the buffer we have just created, so there's no need for the
+    // frame event until then.
+    CancelFrameCallback(manager);
 
     MUTEX_UNLOCK(manager->showLock);
 }
@@ -609,8 +622,7 @@ wl_frame_callback_done(void * data,
     MUTEX_LOCK(manager->showLock);
 
     assert(manager->wl_frame_callback == wl_callback);
-    wl_callback_destroy(manager->wl_frame_callback);
-    manager->wl_frame_callback = NULL;
+    CancelFrameCallback(manager);
 
     if (manager->wlSurface) {
         const bool hasSomethingToSend = (manager->bufferForDraw.damageList != NULL);
@@ -639,6 +651,17 @@ ScheduleFrameCallback(WLSurfaceBufferManager * manager)
     if (!manager->wl_frame_callback) {
         manager->wl_frame_callback = wl_surface_frame(manager->wlSurface);
         wl_callback_add_listener(manager->wl_frame_callback, &wl_frame_callback_listener, manager);
+    }
+}
+
+static void
+CancelFrameCallback(WLSurfaceBufferManager * manager)
+{
+    ASSERT_SHOW_LOCK_IS_HELD(manager);
+
+    if (manager->wl_frame_callback) {
+        wl_callback_destroy(manager->wl_frame_callback);
+        manager->wl_frame_callback = NULL;
     }
 }
 
@@ -846,10 +869,7 @@ WLSBM_SurfaceAssign(WLSurfaceBufferManager * manager, struct wl_surface* wl_surf
         manager->isBufferAttached = false;
         // The "frame" callback depends on the surface; when changing the surface,
         // cancel any associated pending callbacks:
-        if (manager->wl_frame_callback) {
-            wl_callback_destroy(manager->wl_frame_callback);
-            manager->wl_frame_callback = NULL;
-        }
+        CancelFrameCallback(manager);
     } else {
         assert(manager->wlSurface == wl_surface);
     }
@@ -865,9 +885,8 @@ WLSBM_Destroy(WLSurfaceBufferManager * manager)
     // because their callbacks retain a pointer to this manager.
     MUTEX_LOCK(manager->showLock);
     MUTEX_LOCK(manager->drawLock);
-    if (manager->wl_frame_callback) {
-        wl_callback_destroy(manager->wl_frame_callback);
-    }
+
+    CancelFrameCallback(manager);
     DrawBufferDestroy(manager);
 
     if (manager->bufferForShow.wlSurfaceBuffer) {

--- a/src/java.desktop/unix/native/libawt_wlawt/WLComponentPeer.c
+++ b/src/java.desktop/unix/native/libawt_wlawt/WLComponentPeer.c
@@ -39,7 +39,6 @@
 #include "wakefield-client-protocol.h"
 #endif
 
-static jfieldID nativePtrID;
 static jmethodID postWindowClosingMID;
 static jmethodID notifyConfiguredMID;
 static jmethodID notifyEnteredOutputMID;
@@ -303,7 +302,6 @@ JNIEXPORT void JNICALL
 Java_sun_awt_wl_WLComponentPeer_initIDs
         (JNIEnv *env, jclass clazz)
 {
-    CHECK_NULL(nativePtrID = (*env)->GetFieldID(env, clazz, "nativePtr", "J"));
     CHECK_NULL_THROW_IE(env,
                         notifyConfiguredMID = (*env)->GetMethodID(env, clazz, "notifyConfigured", "(IIIIZZ)V"),
                         "Failed to find method WLComponentPeer.notifyConfigured");


### PR DESCRIPTION
When the size of the buffer changes, cancel the frame callback and make sure that the next surface commit happens with the new buffer.