### PR TITLE
JBR-6468 Wayland: java/awt/datatransfer/MimeFormatsTest.java fails by timeout

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -822,6 +822,7 @@ jdk_awt_wayland = \
     -java/awt/datatransfer/ImageTransfer/ImageTransferTest.java \
     -java/awt/datatransfer/Independence/IndependenceAWTTest.java \
     -java/awt/datatransfer/Independence/IndependenceSwingTest.java \
+    -java/awt/datatransfer/MimeFormatsTest.java \
     -java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java \
     -java/awt/datatransfer/SystemSelection/SystemSelectionAWTTest.java \
     -java/awt/datatransfer/SystemSelection/SystemSelectionSwingTest.java \


### PR DESCRIPTION
[JBR-6468](https://youtrack.jetbrains.com/issue/JBR-6468) Wayland: java/awt/datatransfer/MimeFormatsTest.java fails by timeout

Excluded the test from `jdk_awt_wayland` because it relies on `clipboard.setContents()`, which is not guaranteed to succeed in a Wayland environment unless there was some recent user input. See for example [wl_data_device:set_selection](https://wayland.app/protocols/wayland#wl_data_device:request:set_selection) that requires a "serial number of the event that triggered this request".