### PR TITLE
JBR-6469 Wayland: java/awt/image/ColorModel/DrawCustomColorModel.java throws UnsupportedOperationException

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLSMGraphicsConfig.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLSMGraphicsConfig.java
@@ -32,7 +32,9 @@ import sun.java2d.wl.WLSMSurfaceData;
 import sun.util.logging.PlatformLogger;
 
 import java.awt.Transparency;
+import java.awt.color.ColorSpace;
 import java.awt.image.ColorModel;
+import java.awt.image.DataBuffer;
 import java.awt.image.DirectColorModel;
 
 /**
@@ -57,11 +59,9 @@ public class WLSMGraphicsConfig extends WLGraphicsConfig {
                                boolean translucencyCapable) {
         super(device, width, height, scale);
         this.translucencyCapable = translucencyCapable;
-        this.colorModel
-                = translucencyCapable
-                ? new DirectColorModel(32, 0xff0000, 0xff00, 0xff, 0xff000000)
-                : new DirectColorModel(24, 0xff0000, 0xff00, 0xff);
-        this.surfaceType = translucencyCapable ? SurfaceType.IntArgb : SurfaceType.IntRgb;
+        this.colorModel = colorModelFor(translucencyCapable ? Transparency.TRANSLUCENT : Transparency.OPAQUE);
+        // Note: GNOME Shell definitely expects alpha values to be pre-multiplied
+        this.surfaceType = translucencyCapable ? SurfaceType.IntArgbPre : SurfaceType.IntRgb;
     }
 
     public static WLSMGraphicsConfig getConfig(WLGraphicsDevice device,
@@ -87,12 +87,23 @@ public class WLSMGraphicsConfig extends WLGraphicsConfig {
 
     @Override
     public ColorModel getColorModel(int transparency) {
-        return switch (transparency) {
-            case Transparency.OPAQUE -> new DirectColorModel(24, 0xff0000, 0xff00, 0xff);
-            case Transparency.BITMASK ->  new DirectColorModel(25, 0xff0000, 0xff00, 0xff, 0x1000000);
-            case Transparency.TRANSLUCENT -> new DirectColorModel(32, 0xff0000, 0xff00, 0xff, 0xff000000);
-            default -> null;
-        };
+        return colorModelFor(transparency);
+    }
+
+    private static DirectColorModel colorModelFor(int transparency) {
+        switch (transparency) {
+            case Transparency.OPAQUE:
+                return new DirectColorModel(24, 0xff0000, 0xff00, 0xff);
+            case Transparency.BITMASK:
+                return new DirectColorModel(25, 0xff0000, 0xff00, 0xff, 0x1000000);
+            case Transparency.TRANSLUCENT:
+                ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+                return new DirectColorModel(cs, 32,
+                        0xff0000, 0xff00, 0xff, 0xff000000,
+                        true, DataBuffer.TYPE_INT);
+        default:
+            return null;
+        }
     }
 
     public SurfaceData createSurfaceData(WLComponentPeer peer) {

--- a/src/java.desktop/unix/classes/sun/java2d/wl/WLSMSurfaceData.java
+++ b/src/java.desktop/unix/classes/sun/java2d/wl/WLSMSurfaceData.java
@@ -95,6 +95,13 @@ public class WLSMSurfaceData extends SurfaceData implements WLSurfaceDataExt {
 
     @Override
     public Raster getRaster(int x, int y, int w, int h) {
+        // Can do something like the following:
+        // Raster r = getColorModel().createCompatibleWritableRaster(w, h);
+        // copy surface data to this raster
+        // save a reference to this raster
+        // return r;
+        // then in flush() check if raster was modified and take pixels from there
+        // This is obviously suboptimal and shouldn't be used in performance-critical situations.
         throw new UnsupportedOperationException("Not implemented yet");
     }
 


### PR DESCRIPTION
[JBR-6469](https://youtrack.jetbrains.com/issue/JBR-6469) Wayland: java/awt/image/ColorModel/DrawCustomColorModel.java throws UnsupportedOperationException

When surface's type is `SurfaceType.IntArgb`, an unusual blitting loop called `OpaqueCopyArgbToAny` is used to draw an image onto Frame's graphics. That loop requires the target surface to provide its raster, which no platform surfaces really implement and `WLSMSurfaceData.getRaster()` throws UOE.

With an experiment I proved that at least the GNOME Shell implementation of the Wayland server expects memory buffer to have their alpha pre-multiplied, so the correct surface type should be `SurfaceType.IntArgbPre` anyway and that avoids that loop and makes the test pass. I also corrected the color model to indicate that the color components have their alpha pre-multiplied.

This gives correct color values when a semi-transparent Frame is placed on top of some other window (checked by taking a screenshot and measuring the color values in GIMP).