### PR TITLE
JBR-6419 - fix macos-aarch64 build problem

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -711,7 +711,7 @@ char* java_lang_String::as_utf8_string(oop java_string, typeArrayOop value, int 
 
 bool java_lang_String::equals(oop java_string, const jchar* chars, int len) {
   assert(java_string->klass() == vmClasses::String_klass()
-         || VM_EnhancedRedefineClasses::is_inside_redefinition() && java_string->klass()->newest_version() == vmClasses::String_klass(),
+         || (Universe::is_inside_redefinition() && java_string->klass()->newest_version() == vmClasses::String_klass()),
          "must be java_string");
   typeArrayOop value = java_lang_String::value_no_keepalive(java_string);
   int length = java_lang_String::length(java_string, value);
@@ -1396,7 +1396,7 @@ BasicType java_lang_Class::as_BasicType(oop java_class, Klass** reference_klass)
 oop java_lang_Class::primitive_mirror(BasicType t) {
   oop mirror = Universe::java_mirror(t);
   assert(mirror != nullptr && (mirror->is_a(vmClasses::Class_klass())
-         || (VM_EnhancedRedefineClasses::is_inside_redefinition() && vmClasses::Class_klass()->old_version() != NULL && mirror->is_a(vmClasses::Class_klass()->old_version()))), "must be a Class");
+         || (Universe::is_inside_redefinition() && vmClasses::Class_klass()->old_version() != NULL && mirror->is_a(vmClasses::Class_klass()->old_version()))), "must be a Class");
   assert(is_primitive(mirror), "must be primitive");
   return mirror;
 }

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -129,7 +129,7 @@ int java_lang_String::length(oop java_string) {
 
 bool java_lang_String::is_instance(oop obj) {
   return obj != nullptr && (obj->klass() == vmClasses::String_klass()
-         || (VM_EnhancedRedefineClasses::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::String_klass()));
+         || (Universe::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::String_klass()));
 }
 
 // Accessors
@@ -267,12 +267,12 @@ inline bool java_lang_invoke_MethodHandleNatives_CallSiteContext::is_instance(oo
 
 inline bool java_lang_invoke_MemberName::is_instance(oop obj) {
   return obj != nullptr && (obj->klass() == vmClasses::MemberName_klass()
-                         || (VM_EnhancedRedefineClasses::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::MemberName_klass()));
+                         || (Universe::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::MemberName_klass()));
 }
 
 inline bool java_lang_invoke_ResolvedMethodName::is_instance(oop obj) {
   return obj != nullptr && (obj->klass() == vmClasses::ResolvedMethodName_klass()
-                         || (VM_EnhancedRedefineClasses::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::ResolvedMethodName_klass()));
+                         || (Universe::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::ResolvedMethodName_klass()));
 }
 
 inline bool java_lang_invoke_MethodType::is_instance(oop obj) {
@@ -285,7 +285,7 @@ inline bool java_lang_invoke_MethodHandle::is_instance(oop obj) {
 
 inline bool java_lang_Class::is_instance(oop obj) {
   return obj != nullptr && (obj->klass() == vmClasses::Class_klass()
-                         || (VM_EnhancedRedefineClasses::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::Class_klass()));
+                         || (Universe::is_inside_redefinition() && obj->klass()->newest_version() == vmClasses::Class_klass()));
 }
 
 inline Klass* java_lang_Class::as_Klass(oop java_class) {
@@ -321,12 +321,12 @@ inline size_t java_lang_Class::oop_size(oop java_class) {
 
 inline bool java_lang_invoke_DirectMethodHandle::is_instance(oop obj) {
   return obj != nullptr && (is_subclass(obj->klass())
-         || (VM_EnhancedRedefineClasses::is_inside_redefinition() && is_subclass(obj->klass()->newest_version())));
+         || (Universe::is_inside_redefinition() && is_subclass(obj->klass()->newest_version())));
 }
 
 inline bool java_lang_invoke_DirectMethodHandle_StaticAccessor::is_instance(oop obj) {
   return obj != nullptr && (is_subclass(obj->klass())
-         || (VM_EnhancedRedefineClasses::is_inside_redefinition() && is_subclass(obj->klass()->newest_version())));
+         || (Universe::is_inside_redefinition() && is_subclass(obj->klass()->newest_version())));
 }
 
 inline bool java_lang_invoke_DirectMethodHandle_Accessor::is_instance(oop obj) {

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -160,7 +160,8 @@ int             Universe::_base_vtable_size = 0;
 bool            Universe::_bootstrapping = false;
 bool            Universe::_module_initialized = false;
 bool            Universe::_fully_initialized = false;
-bool            Universe::_is_redefining_gc_run = false; // FIXME: review
+bool            Universe::_is_redefining_gc_run = false;
+bool            Universe::_is_inside_redefinition = false;
 
 OopStorage*     Universe::_vm_weak = nullptr;
 OopStorage*     Universe::_vm_global = nullptr;

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -195,6 +195,7 @@ class Universe: AllStatic {
   static uintptr_t _verify_oop_mask;
   static uintptr_t _verify_oop_bits;
   static bool _is_redefining_gc_run;
+  static bool _is_inside_redefinition;
 
   // Table of primitive type mirrors, excluding T_OBJECT and T_ARRAY
   // but including T_VOID, hence the index including T_VOID
@@ -210,9 +211,11 @@ class Universe: AllStatic {
   static void calculate_verify_data(HeapWord* low_boundary, HeapWord* high_boundary) PRODUCT_RETURN;
   static void set_verify_data(uintptr_t mask, uintptr_t bits) PRODUCT_RETURN;
 
-  // Advanced class redefinition. FIXME: review?
+  // (DCEVM) Advanced class redefinition.
   static bool is_redefining_gc_run()               { return _is_redefining_gc_run; }
   static void set_redefining_gc_run(bool b)        { _is_redefining_gc_run = b;    }
+  static bool is_inside_redefinition()               { return _is_inside_redefinition; }
+  static void set_inside_redefinition(bool b)        { _is_inside_redefinition = b;    }
 
   // Known classes in the VM
   static Klass* boolArrayKlassObj()                 { return typeArrayKlassObj(T_BOOLEAN); }

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -83,7 +83,6 @@ int         VM_EnhancedRedefineClasses::_deleted_methods_length  = 0;
 int         VM_EnhancedRedefineClasses::_added_methods_length    = 0;
 Klass*      VM_EnhancedRedefineClasses::_the_class_oop = nullptr;
 u8        VM_EnhancedRedefineClasses::_id_counter = 0;
-bool      VM_EnhancedRedefineClasses::_is_inside_redefinition = false;
 
 //
 // Create new instance of enhanced class redefiner.
@@ -525,7 +524,7 @@ void VM_EnhancedRedefineClasses::doit() {
     _timer_vm_op_doit.start();
   }
 
-  _is_inside_redefinition = true;
+  Universe::set_inside_redefinition(true);
 
   // Mark methods seen on stack and everywhere else so old methods are not
   // cleaned up if they're on the stack.
@@ -757,7 +756,7 @@ void VM_EnhancedRedefineClasses::doit() {
   }
 #endif
 
-  _is_inside_redefinition = false;
+  Universe::set_inside_redefinition(false);
   _timer_vm_op_doit.stop();
 }
 

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.hpp
@@ -60,7 +60,6 @@ class VM_EnhancedRedefineClasses: public VM_GC_Operation {
   static int           _added_methods_length;
   static Klass*        _the_class_oop;
   static u8            _id_counter;
-  static bool          _is_inside_redefinition;
 
   // The instance fields are used to pass information from
   // doit_prologue() to doit() and doit_epilogue().
@@ -200,8 +199,5 @@ class VM_EnhancedRedefineClasses: public VM_GC_Operation {
   // Modifiable test must be shared between IsModifiableClass query
   // and redefine implementation
   static bool is_modifiable_class(oop klass_mirror);
-  static bool is_inside_redefinition() {
-    return _is_inside_redefinition;
-  }
 };
 #endif // SHARE_VM_PRIMS_JVMTIREDEFINECLASSES2_HPP


### PR DESCRIPTION
Move flag is_inside_redefinition to Universe:: to fix macos-aarch64 build, same problem as in jbr17, that is already fixed & merged.