### PR TITLE
JBR-6648 - Fix ObjectCollectedException in enhanced redefineClasses d…

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/VirtualMachineImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/VirtualMachineImpl.c
@@ -487,6 +487,8 @@ redefineClasses(PacketInputStream *in, PacketOutputStream *out)
             }
             for (i = 0; i < classCount; i++) {
                 classIds[i] = commonRef_refToID(env, classDefs[i].klass);
+                /* remove tags of old classes */
+                commonRef_deleteTags(env, classIds[i]);
             }
         }
 
@@ -499,19 +501,17 @@ redefineClasses(PacketInputStream *in, PacketOutputStream *out)
             for ( i = 0 ; i < classCount; i++ ) {
                 eventHandler_freeClassBreakpoints(classDefs[i].klass);
             }
-
-            if (gdata->isEnhancedClassRedefinitionEnabled && classIds != NULL) {
-                /* Update tags in jvmti to use new classes */
-                for ( i = 0 ; i < classCount; i++ ) {
-                    /* pointer in classIds[i] is updated by advanced redefinition to a new class */
-                    error = commonRef_updateTags(env, classIds[i]);
-                    if (error != JVMTI_ERROR_NONE) {
-                        break;
-                    }
-                }
-                jvmtiDeallocate((void*) classIds);
+        }
+        if (gdata->isEnhancedClassRedefinitionEnabled && classIds != NULL) {
+          /* install new tags in jvmti to use new classes */
+          for ( i = 0 ; i < classCount; i++ ) {
+            /* pointer in classIds[i] is updated by advanced redefinition to a new class */
+            error = commonRef_updateTags(env, classIds[i]);
+            if (error != JVMTI_ERROR_NONE) {
+              break;
             }
-
+          }
+          jvmtiDeallocate((void*) classIds);
         }
     }
 

--- a/src/jdk.jdwp.agent/share/native/libjdwp/commonRef.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/commonRef.c
@@ -717,6 +717,35 @@ commonRef_unlock(void)
  * Update JVMTI tags, used from enhanced redefinition
  */
 jvmtiError
+commonRef_deleteTags(JNIEnv *env, jlong id)
+{
+  jvmtiError error;
+
+  error = JVMTI_ERROR_NONE;
+
+  if (id == NULL_OBJECT_ID) {
+    return error;
+  }
+
+  debugMonitorEnter(gdata->refLock); {
+    RefNode *node;
+
+    node = findNodeByID(env, id);
+    if (node != NULL) {
+      error = JVMTI_FUNC_PTR(gdata->jvmti, SetTag)
+              (gdata->jvmti, node->ref, NULL_OBJECT_ID);
+    } else {
+      printf("Node not found\n");
+    }
+  } debugMonitorExit(gdata->refLock);
+
+  return error;
+}
+
+/*
+ * Update JVMTI tags, used from enhanced redefinition
+ */
+jvmtiError
 commonRef_updateTags(JNIEnv *env, jlong id)
 {
     jvmtiError error;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/commonRef.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/commonRef.h
@@ -43,6 +43,7 @@ void commonRef_compact(void);
 void commonRef_lock(void);
 void commonRef_unlock(void);
 
+jvmtiError commonRef_deleteTags(JNIEnv *env, jlong id);
 jvmtiError commonRef_updateTags(JNIEnv *env, jlong id);
 
 #endif


### PR DESCRIPTION
JBR-6648 - Fix ObjectCollectedException in enhanced redefineClasses due to stale jvmtiTagMap entries

- modification is safe because it runs in AllowEnhancedClassRedefinition only