### PR TITLE
JBR-6522 macOS: SIGSEGV at [libawt_lwawt.dylib+0x8eaa8] MTLGC_DestroyMTLGraphicsConfig

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -655,9 +655,9 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     CHECK_PREVIOUS_OP(MTL_OP_OTHER);
                     jlong pConfigInfo = NEXT_LONG(b);
                     CONTINUE_IF_NULL(mtlc);
+                    [mtlc commitCommandBuffer:YES display:NO];
                     MTLTR_FreeGlyphCacheAA();
                     MTLTR_FreeGlyphCacheLCD();
-                    [mtlc.encoderManager endEncoder];
                     MTLGC_DestroyMTLGraphicsConfig(pConfigInfo);
                     mtlc = NULL;
                     break;


### PR DESCRIPTION
Performing flush of pending rendering operation before destroying MTLGraphicsConfig