### PR TITLE
JBR-6647 Disable check for final field access from method $$ha$clinit

### DIFF
--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1033,14 +1033,16 @@ void LinkResolver::resolve_field(fieldDescriptor& fd,
                                                      !fd.is_static() &&
                                                      !m->is_object_initializer());
 
-        if (is_initialized_static_final_update || is_initialized_instance_final_update) {
-          ResourceMark rm(THREAD);
-          stringStream ss;
-          ss.print("Update to %s final field %s.%s attempted from a different method (%s) than the initializer method %s ",
-                   is_static ? "static" : "non-static", resolved_klass->external_name(), fd.name()->as_C_string(),
-                   m->name()->as_C_string(),
-                   is_static ? "<clinit>" : "<init>");
-          THROW_MSG(vmSymbols::java_lang_IllegalAccessError(), ss.as_string());
+        if (!AllowEnhancedClassRedefinition || !m->name()->equals("$$ha$clinit")) {
+          if (is_initialized_static_final_update || is_initialized_instance_final_update) {
+            ResourceMark rm(THREAD);
+            stringStream ss;
+            ss.print("Update to %s final field %s.%s attempted from a different method (%s) than the initializer method %s ",
+                    is_static ? "static" : "non-static", resolved_klass->external_name(), fd.name()->as_C_string(),
+                    m->name()->as_C_string(),
+                    is_static ? "<clinit>" : "<init>");
+            THROW_MSG(vmSymbols::java_lang_IllegalAccessError(), ss.as_string());
+          }
         }
       }
     }


### PR DESCRIPTION
Kotlin compiler can create a new static variable `INSTANCE` on redefinition, that is normally initialized by `<clinit>`, but in case of redefinition the initializer is not called, since instances of static variables from old class must be preserved and initizelizer for a new class shoudl initialize only new variables. So it is not work for JVM level dcevm, but for high level agent. HotswapAgent solves the problem creating static method `$$ha$clinit`, that serves for initialization of new static varables.