### PR TITLE
fixup! JBR-6246 add default CDS archives into jbrsdk distributions

### DIFF
--- a/test/jdk/jb/build/CDSArchivesTest.sh
+++ b/test/jdk/jb/build/CDSArchivesTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 # @test
 # @summary CDSArchivesTest.sh checks jsa files exist in jbrsdk distributions, jbr distributions are skipped
 # @run shell CDSArchivesTest.sh
@@ -9,14 +11,10 @@ if [ -z "${TESTJAVA}" ]; then
   exit 1
 fi
 
-source ${TESTJAVA}/release
+IMPLEMENTOR_VERSION=$(cat ${TESTJAVA}/release | grep "IMPLEMENTOR_VERSION" | cut -d"=" -f2)
 
-echo "${TESTJAVA}/release"
-cat ${TESTJAVA}/release
-echo
-
-echo "Checking $IMPLEMENTOR_VERSION"
-if [[ "$IMPLEMENTOR_VERSION" != *"JBRSDK"* ]]; then
+echo "Checking ${IMPLEMENTOR_VERSION}"
+if [ "${IMPLEMENTOR_VERSION}" != *"JBRSDK"* ]; then
   echo "Test executed for JBRSDK only"
   echo "skipping the test"
   exit 0


### PR DESCRIPTION
The previous version of the test works well only when the test was launched from Terminal. When it was launched via jtreg it could not correctly read the variable IMPLEMENTOR_VERSION using source on Linux.
The test was rewritten to read the value for this variable in another way - via grep.