### PR TITLE
JBR-6674 Fix parallel oops iteration in dcevm redefinition

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2068,11 +2068,6 @@ void G1CollectedHeap::heap_region_iterate(HeapRegionIndexClosure* cl) const {
   _hrm.iterate(cl);
 }
 
-void G1CollectedHeap::object_par_iterate(ObjectClosure* cl) {
-  G1IterateObjectClosureTask iocl_task(cl, this);
-  workers()->run_task(&iocl_task);
-}
-
 void G1CollectedHeap::heap_region_par_iterate_from_worker_offset(HeapRegionClosure* cl,
                                                                  HeapRegionClaimer *hrclaimer,
                                                                  uint worker_id) const {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1064,7 +1064,6 @@ public:
   // Iteration functions.
 
   void object_iterate_parallel(ObjectClosure* cl, uint worker_id, HeapRegionClaimer* claimer);
-  void object_par_iterate(ObjectClosure* cl);
 
   // Iterate over all objects, calling "cl.do_object" on each.
   void object_iterate(ObjectClosure* cl) override;

--- a/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiEnhancedRedefineClasses.cpp
@@ -500,6 +500,25 @@ public:
   }
 };
 
+class ChangePointersObjectTask : public WorkerTask {
+private:
+  ChangePointersOopClosure<StoreBarrier>* _cl;
+  ParallelObjectIterator* _poi;
+  bool _needs_instance_update;
+public:
+  ChangePointersObjectTask(ChangePointersOopClosure<StoreBarrier>* cl, ParallelObjectIterator* poi) : WorkerTask("IterateObject Closure"),
+                                                                                                      _cl(cl), _poi(poi), _needs_instance_update(false) { }
+
+  virtual void work(uint worker_id) {
+    HandleMark hm(Thread::current());   // make sure any handles created are deleted
+    ChangePointersObjectClosure objectClosure(_cl);
+    _poi->object_iterate(&objectClosure, worker_id);
+    _needs_instance_update = _needs_instance_update || objectClosure.needs_instance_update();
+  }
+  bool needs_instance_update() {
+    return _needs_instance_update;
+  }
+};
 
 // Main transformation method - runs in VM thread.
 //  - for each scratch class call redefine_single_class
@@ -580,7 +599,7 @@ void VM_EnhancedRedefineClasses::doit() {
 
   ChangePointersOopClosure<StoreNoBarrier> oopClosureNoBarrier;
   ChangePointersOopClosure<StoreBarrier> oopClosure;
-  ChangePointersObjectClosure objectClosure(&oopClosure);
+  bool needs_instance_update = false;
 
   log_trace(redefine, class, redefine, metadata)("Before updating instances");
   {
@@ -602,27 +621,25 @@ void VM_EnhancedRedefineClasses::doit() {
 #endif
     }
 
-    Universe::heap()->ensure_parsability(false);
-#if INCLUDE_G1GC
-    if (UseG1GC) {
-      if (log_is_enabled(Info, redefine, class, timer)) {
-        _timer_heap_iterate.start();
-      }
-      // returns after the iteration is finished
-      G1CollectedHeap::heap()->object_par_iterate(&objectClosure);
-      _timer_heap_iterate.stop();
-    } else {
-#endif
-      if (log_is_enabled(Info, redefine, class, timer)) {
-        _timer_heap_iterate.start();
-      }
-      Universe::heap()->object_iterate(&objectClosure);
-      _timer_heap_iterate.stop();
-#if INCLUDE_G1GC
+    if (log_is_enabled(Info, redefine, class, timer)) {
+      _timer_heap_iterate.start();
     }
-#endif
+    Universe::heap()->ensure_parsability(false);
+    WorkerThreads* workers = Universe::heap()->safepoint_workers();
+    if (workers != nullptr && workers->active_workers() > 1) {
+      ParallelObjectIterator poi(workers->active_workers());
+      ChangePointersObjectTask objectTask(&oopClosure, &poi);
+      workers->run_task(&objectTask);
+      needs_instance_update = objectTask.needs_instance_update();
+    } else {
+      ChangePointersObjectClosure objectClosure(&oopClosure);
+      Universe::heap()->object_iterate(&objectClosure);
+      needs_instance_update = objectClosure.needs_instance_update();
+    }
 
     root_oops_do(&oopClosureNoBarrier);
+
+    _timer_heap_iterate.stop();
 
 #if INCLUDE_G1GC
     if (UseG1GC) {
@@ -705,9 +722,8 @@ void VM_EnhancedRedefineClasses::doit() {
     ClassUnloadingWithConcurrentMark = false;
   }
 
-  if (objectClosure.needs_instance_update()) {
+  if (needs_instance_update) {
     // Do a full garbage collection to update the instance sizes accordingly
-
     log_trace(redefine, class, redefine, metadata)("Before redefinition full GC run");
 
     if (log_is_enabled(Info, redefine, class, timer)) {


### PR DESCRIPTION
This patch addresses unsynchronized parallel access to ChangePointersObjectClosure._tmp_obj by creating a separate instance for each thread, enhancing thread safety. Additionally, it deems parallel DCEVM iteration in G1 as redundant and removes it.