### PR TITLE
JBR-6763 Wayland: handle popup_done event

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -1185,10 +1185,9 @@ public class WLComponentPeer implements ComponentPeer {
     }
 
     void notifyPopupDone() {
-        if (targetIsWlPopup()) {
-            setVisible(false);
-            WLToolkit.postEvent(new WindowEvent((Window) target, WindowEvent.WINDOW_CLOSING));
-        }
+        assert(targetIsWlPopup());
+        setVisible(false);
+        WLToolkit.postEvent(new WindowEvent((Window) target, WindowEvent.WINDOW_CLOSING));
     }
 
     private WLGraphicsDevice getGraphicsDevice() {

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -1184,6 +1184,13 @@ public class WLComponentPeer implements ComponentPeer {
         checkIfOnNewScreen();
     }
 
+    void notifyPopupDone() {
+        if (targetIsWlPopup()) {
+            setVisible(false);
+            WLToolkit.postEvent(new WindowEvent((Window) target, WindowEvent.WINDOW_CLOSING));
+        }
+    }
+
     private WLGraphicsDevice getGraphicsDevice() {
         int scale = 0;
         WLGraphicsDevice theDevice = null;

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -165,7 +165,9 @@ public class WLComponentPeer implements ComponentPeer {
     }
 
     boolean isVisible() {
-        return visible && hasSurface();
+        synchronized (getStateLock()) {
+            return visible && hasSurface();
+        }
     }
 
     boolean hasSurface() {
@@ -236,7 +238,9 @@ public class WLComponentPeer implements ComponentPeer {
     }
 
     protected void wlSetVisible(boolean v) {
-        this.visible = v;
+        synchronized (getStateLock()) {
+            this.visible = v;
+        }
         if (v) {
             String title = getTitle();
             boolean isWlPopup = targetIsWlPopup();

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -1193,6 +1193,7 @@ public class WLComponentPeer implements ComponentPeer {
     void notifyPopupDone() {
         assert(targetIsWlPopup());
         setVisible(false);
+        // TODO: may need a better way of notifying interested components about popup disappearance
         WLToolkit.postEvent(new WindowEvent((Window) target, WindowEvent.WINDOW_CLOSING));
     }
 

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -239,6 +239,8 @@ public class WLComponentPeer implements ComponentPeer {
 
     protected void wlSetVisible(boolean v) {
         synchronized (getStateLock()) {
+            if (this.visible == v) return;
+            
             this.visible = v;
         }
         if (v) {

--- a/src/java.desktop/unix/native/libawt_wlawt/WLComponentPeer.c
+++ b/src/java.desktop/unix/native/libawt_wlawt/WLComponentPeer.c
@@ -43,6 +43,7 @@ static jmethodID postWindowClosingMID;
 static jmethodID notifyConfiguredMID;
 static jmethodID notifyEnteredOutputMID;
 static jmethodID notifyLeftOutputMID;
+static jmethodID notifyPopupDoneMID;
 
 struct activation_token_list_item {
     struct xdg_activation_token_v1 *token;
@@ -261,6 +262,14 @@ xdg_popup_done(void *data,
                struct xdg_popup *xdg_popup)
 {
     J2dTrace1(J2D_TRACE_INFO, "WLComponentPeer: xdg_popup_done(%p)\n", xdg_popup);
+    struct WLFrame *frame = (struct WLFrame *) data;
+    JNIEnv *env = getEnv();
+    const jobject nativeFramePeer = (*env)->NewLocalRef(env, frame->nativeFramePeer);
+    if (nativeFramePeer) {
+        (*env)->CallVoidMethod(env, nativeFramePeer, notifyPopupDoneMID);
+        (*env)->DeleteLocalRef(env, nativeFramePeer);
+        JNU_CHECK_EXCEPTION(env);
+    }
 }
 
 static void
@@ -311,6 +320,9 @@ Java_sun_awt_wl_WLComponentPeer_initIDs
     CHECK_NULL_THROW_IE(env,
                         notifyLeftOutputMID = (*env)->GetMethodID(env, clazz, "notifyLeftOutput", "(I)V"),
                         "Failed to find method WLComponentPeer.notifyLeftOutput");
+    CHECK_NULL_THROW_IE(env,
+                        notifyPopupDoneMID = (*env)->GetMethodID(env, clazz, "notifyPopupDone", "()V"),
+                        "Failed to find method WLComponentPeer.notifyPopupDone");
 }
 
 JNIEXPORT void JNICALL

--- a/src/java.desktop/unix/native/libawt_wlawt/WLComponentPeer.c
+++ b/src/java.desktop/unix/native/libawt_wlawt/WLComponentPeer.c
@@ -262,7 +262,7 @@ xdg_popup_done(void *data,
                struct xdg_popup *xdg_popup)
 {
     J2dTrace1(J2D_TRACE_INFO, "WLComponentPeer: xdg_popup_done(%p)\n", xdg_popup);
-    struct WLFrame *frame = (struct WLFrame *) data;
+    struct WLFrame *frame = data;
     JNIEnv *env = getEnv();
     const jobject nativeFramePeer = (*env)->NewLocalRef(env, frame->nativeFramePeer);
     if (nativeFramePeer) {


### PR DESCRIPTION
Certain Wayland compositors (wlroots) invalidate xdg_surface after window with popup loses focus. Subsequent attempts to commit the popup window fail with protocol error
"xdg_surface has never been configured".

Handle popup_done event by hiding the popup window and emitting WINDOW_CLOSING Window event.