### PR TITLE
JBR-6593 Set unique name for the AccessibleAnnouncer thread

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/AccessibleAnnouncer.java
+++ b/src/java.desktop/share/classes/sun/swing/AccessibleAnnouncer.java
@@ -26,6 +26,7 @@
 
 package sun.swing;
 
+import jdk.internal.misc.InnocuousThread;
 import sun.awt.AWTThreading;
 
 import javax.accessibility.Accessible;
@@ -82,7 +83,11 @@ public class AccessibleAnnouncer {
         // so execute it on a background thread.
         if (System.getProperty("os.name").startsWith("Windows")) {
             if (executor == null) {
-                executor = Executors.newSingleThreadExecutor();
+                executor = Executors.newSingleThreadExecutor(r -> {
+                    Thread t = InnocuousThread.newSystemThread(AccessibleAnnouncer.class.getSimpleName(), r);
+                    t.setDaemon(true);
+                    return t;
+                });
             }
             executor.execute(() -> nativeAnnounce(a, str, priority));
         } else {


### PR DESCRIPTION
Follow-up on #272. Set unique name for the AccessibleAnnouncer thread for easier debugging.
![Thread view in IntelliJ showing AccessibleAnnouncer thread name](https://github.com/JetBrains/JetBrainsRuntime/assets/102954094/45389e61-9871-4506-b9f3-e37ec8dd9995)

