### PR TITLE
JBR-6787 WLToolkit/wsl: crash in WLComponentPeer.setCursor

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -800,7 +800,7 @@ public class WLComponentPeer implements ComponentPeer {
             if (pData == 0) {
                 // instead of destroying and creating new cursor after changing scale could be used caching
                 long oldPData = AWTAccessor.getCursorAccessor().getPData(cursor);
-                if (oldPData != 0) {
+                if (oldPData != 0 && oldPData != -1) {
                     nativeDestroyPredefinedCursor(oldPData);
                 }
 


### PR DESCRIPTION
Added check for unavailable cursor pData