### PR TITLE
JBR-6915 add the option -w into mkimages scripts

### DIFF
--- a/jb/project/tools/common/scripts/common.sh
+++ b/jb/project/tools/common/scripts/common.sh
@@ -17,9 +17,11 @@ function getVersionProp() {
   grep "^${1}" make/conf/version-numbers.conf | cut -d'=' -f2
 }
 
-while getopts ":i?" o; do
+DISABLE_WARNINGS_AS_ERRORS=""
+while getopts ":iw?" o; do
     case "${o}" in
         i) INC_BUILD=1 ;;
+        w) DISABLE_WARNINGS_AS_ERRORS="--disable-warnings-as-errors" ;;
     esac
 done
 shift $((OPTIND-1))

--- a/jb/project/tools/linux/scripts/mkimages_aarch64.sh
+++ b/jb/project/tools/linux/scripts/mkimages_aarch64.sh
@@ -35,6 +35,7 @@ function do_configure {
     --with-version-opt=b"$build_number" \
     --with-boot-jdk="$BOOT_JDK" \
     --enable-cds=yes \
+    $DISABLE_WARNINGS_AS_ERRORS \
     $STATIC_CONF_ARGS \
     $REPRODUCIBLE_BUILD_OPTS \
     $WITH_ZIPPED_NATIVE_DEBUG_SYMBOLS \

--- a/jb/project/tools/linux/scripts/mkimages_x64.sh
+++ b/jb/project/tools/linux/scripts/mkimages_x64.sh
@@ -43,6 +43,7 @@ function do_configure {
     --with-boot-jdk="$BOOT_JDK" \
     --enable-cds=yes \
     $LINUX_TARGET \
+    $DISABLE_WARNINGS_AS_ERRORS \
     $STATIC_CONF_ARGS \
     $REPRODUCIBLE_BUILD_OPTS \
     $WITH_ZIPPED_NATIVE_DEBUG_SYMBOLS \

--- a/jb/project/tools/linux/scripts/mkimages_x86.sh
+++ b/jb/project/tools/linux/scripts/mkimages_x86.sh
@@ -25,6 +25,7 @@ function do_configure {
     --with-boot-jdk="$BOOT_JDK" \
     $STATIC_CONF_ARGS \
     --enable-cds=yes \
+    $DISABLE_WARNINGS_AS_ERRORS \
     $REPRODUCIBLE_BUILD_OPTS \
     $WITH_ZIPPED_NATIVE_DEBUG_SYMBOLS \
     || do_exit $?

--- a/jb/project/tools/mac/scripts/mkimages.sh
+++ b/jb/project/tools/mac/scripts/mkimages.sh
@@ -38,6 +38,7 @@ function do_configure {
     --with-version-opt=b"$build_number" \
     --with-boot-jdk="$BOOT_JDK" \
     --enable-cds=yes \
+    $DISABLE_WARNINGS_AS_ERRORS \
     $STATIC_CONF_ARGS \
     $REPRODUCIBLE_BUILD_OPTS \
     $WITH_ZIPPED_NATIVE_DEBUG_SYMBOLS \

--- a/jb/project/tools/windows/scripts/mkimages_aarch64.sh
+++ b/jb/project/tools/windows/scripts/mkimages_aarch64.sh
@@ -49,6 +49,7 @@ function do_configure {
     --with-nvdacontrollerclient=$NVDA_PATH \
     --disable-ccache \
     --enable-cds=yes \
+    $DISABLE_WARNINGS_AS_ERRORS \
     $STATIC_CONF_ARGS \
     $REPRODUCIBLE_BUILD_OPTS \
     || do_exit $?

--- a/jb/project/tools/windows/scripts/mkimages_x64.sh
+++ b/jb/project/tools/windows/scripts/mkimages_x64.sh
@@ -40,6 +40,7 @@ function do_configure {
     --with-nvdacontrollerclient=$NVDA_PATH \
     --disable-ccache \
     --enable-cds=yes \
+    $DISABLE_WARNINGS_AS_ERRORS \
     $STATIC_CONF_ARGS \
     $REPRODUCIBLE_BUILD_OPTS \
     || do_exit $?

--- a/jb/project/tools/windows/scripts/mkimages_x86.sh
+++ b/jb/project/tools/windows/scripts/mkimages_x86.sh
@@ -36,6 +36,7 @@ function do_configure {
     --with-nvdacontrollerclient=$NVDA_PATH \
     --disable-ccache \
     --enable-cds=yes \
+    $DISABLE_WARNINGS_AS_ERRORS \
     $STATIC_CONF_ARGS \
     $REPRODUCIBLE_BUILD_OPTS \
     || do_exit $?


### PR DESCRIPTION
The option `-w` was introduced into mkimages scripts. The option add the parameter `--disable-warnings-as-errors` into `configure`.
Note: `configure` is not invoked when mkimages scripts are started with the option `-i` 