### PR TITLE
JBR-6911 IDE crashes (EXC_BAD_ACCESS) after disconnecting the secondary display if a markdown file is opened (macOS Sonoma 14.4.1)

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
@@ -255,8 +255,11 @@ union StateIndex {
 }
 
 - (void) dealloc {
-    [super dealloc];
     [computeStates release];
+    self.library = nil;
+    self.shaders = nil;
+    self.states = nil;
+    [super dealloc];
 }
 @end
 


### PR DESCRIPTION
Corrected invalid usage of dealloc method, fixed memory leaks.