### PR TITLE
JBR-6926 Wayland: fonts are aliased/grainy on first start

### DIFF
--- a/src/java.desktop/unix/classes/sun/java2d/wl/WLVolatileSurfaceManager.java
+++ b/src/java.desktop/unix/classes/sun/java2d/wl/WLVolatileSurfaceManager.java
@@ -26,18 +26,25 @@
 
 package sun.java2d.wl;
 
+import java.awt.Component;
 import java.awt.GraphicsConfiguration;
 import java.awt.ImageCapabilities;
-import java.awt.Transparency;
-import java.awt.image.ColorModel;
-import sun.awt.wl.WLGraphicsConfig;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
 import sun.awt.image.SunVolatileImage;
 import sun.awt.image.VolatileSurfaceManager;
 import sun.java2d.SurfaceData;
 
-public class WLVolatileSurfaceManager extends VolatileSurfaceManager {
+public class WLVolatileSurfaceManager extends VolatileSurfaceManager implements PropertyChangeListener {
+    private static final String SCALE_PROPERTY_NAME = "graphicsContextScaleTransform";
+
     public WLVolatileSurfaceManager(SunVolatileImage vImg, Object context) {
         super(vImg, context);
+        Component component = vImg.getComponent();
+        if (component != null) {
+            component.addPropertyChangeListener(SCALE_PROPERTY_NAME, this);
+        }
     }
 
     protected boolean isAccelerationEnabled() {
@@ -53,5 +60,12 @@ public class WLVolatileSurfaceManager extends VolatileSurfaceManager {
     public ImageCapabilities getCapabilities(GraphicsConfiguration gc) {
         // neither accelerated nor volatile
         return new ImageCapabilities(false);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        assert SCALE_PROPERTY_NAME.equals(evt.getPropertyName());
+
+        displayChanged();
     }
 }


### PR DESCRIPTION
[JBR-6926](https://youtrack.jetbrains.com/issue/JBR-6926) Wayland: fonts are aliased/grainy on first start

The fix is to update volatile images created for offscreen painting of a `Component` whenever that component appears on a monitor with a different scale.