### PR TITLE
JBR-7020 Reorder LCD glyph cache freeing and validation

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGlyphCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGlyphCache.m
@@ -215,37 +215,6 @@
     }
     return JNI_FALSE;
 }
-/**
- * Invalidates all cells in the cache.  Note that this method does not
- * attempt to compact the cache in any way; it just invalidates any cells
- * that already exist.
- */
-- (void) invalidate
-{
-    MTLCacheCellInfo *cellinfo;
-
-    J2dTraceLn(J2D_TRACE_INFO, "MTLGlyphCache.invalidate");
-
-    if (_cacheInfo == NULL) {
-        return;
-    }
-
-    // flush any pending vertices that may be depending on the current
-    // glyph cache layout
-    if (_cacheInfo->Flush != NULL) {
-        _cacheInfo->Flush(_cacheInfo->mtlc);
-    }
-
-    cellinfo = _cacheInfo->head;
-    while (cellinfo != NULL) {
-        if (cellinfo->glyphInfo != NULL) {
-            // if the cell is occupied, notify the base glyph that its
-            // cached version for this cache is about to be invalidated
-            MTLGlyphCache_RemoveCellInfo(cellinfo->glyphInfo, cellinfo);
-        }
-        cellinfo = cellinfo->next;
-    }
-}
 
 /**
  * Invalidates and frees all cells and the cache itself. The "cache" pointer

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
@@ -372,15 +372,15 @@ MTLTR_DrawLCDGlyphViaCache(MTLContext *mtlc, BMTLSDOps *dstOps,
             DisableColorGlyphPainting(mtlc);
         }
 
-        if (!MTLTR_ValidateGlyphCache(mtlc, dstOps, JNI_TRUE)) {
-            return JNI_FALSE;
-        }
-
         if (rgbOrder != lastRGBOrder) {
             // need to invalidate the cache in this case; see comments
             // for lastRGBOrder above
-            [mtlc.glyphCacheLCD invalidate];
+            [mtlc.glyphCacheLCD free];
             lastRGBOrder = rgbOrder;
+        }
+
+        if (!MTLTR_ValidateGlyphCache(mtlc, dstOps, JNI_TRUE)) {
+            return JNI_FALSE;
         }
 
         glyphMode = MODE_USE_CACHE_LCD;


### PR DESCRIPTION
1. As we started committing the command buffer on glyph cache flush, this invalidates the current encoder. We need to `MTLTR_ValidateGlyphCache` after the flush, not before.
2. There's no reason to maintain separate glyph cache invalidation logic for this singe case (which is a no-op in reality), so just free the cache instead.