### PR TITLE
JBR-7028 Implement FPS counter on Linux

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -4507,6 +4507,11 @@ public class Window extends Container implements Accessible {
                 return w.getOwnedWindows_NoClientCode();
             }
 
+            public boolean countersEnabled(Window w) {
+                // May want to selectively enable or disable counters per window
+                return counters != null;
+            }
+
             public void bumpCounter(Window w, String counterName) {
                 Objects.requireNonNull(w);
                 Objects.requireNonNull(counterName);

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -410,6 +410,7 @@ public class Window extends Container implements Accessible {
 
     private static final PlatformLogger log = PlatformLogger.getLogger("java.awt.Window");
     private static final PlatformLogger focusRequestLog = PlatformLogger.getLogger("jb.focus.requests");
+    private static final PlatformLogger perfLog = PlatformLogger.getLogger("awt.window.counters");
 
     private static final boolean locationByPlatformProp;
 
@@ -4459,6 +4460,8 @@ public class Window extends Container implements Accessible {
     }
 
     static {
+        String counters = System.getProperty("awt.window.counters");
+
         AWTAccessor.setWindowAccessor(new AWTAccessor.WindowAccessor() {
             public void updateWindow(Window window) {
                 window.updateWindow();
@@ -4503,12 +4506,98 @@ public class Window extends Container implements Accessible {
             public Window[] getOwnedWindows(Window w) {
                 return w.getOwnedWindows_NoClientCode();
             }
+
+            public void bumpCounter(Window w, String counterName) {
+                Objects.requireNonNull(w);
+                Objects.requireNonNull(counterName);
+
+                PerfCounter newCounter;
+                long curTimeNanos = System.nanoTime();
+                synchronized (w.perfCounters) {
+                    newCounter = w.perfCounters.compute(counterName, (k, v) ->
+                            v == null
+                            ? new PerfCounter(curTimeNanos, 1L)
+                            : new PerfCounter(curTimeNanos, v.value + 1));
+                }
+                PerfCounter prevCounter;
+                synchronized (w.perfCountersPrev) {
+                    prevCounter = w.perfCountersPrev.putIfAbsent(counterName, newCounter);
+                }
+                if (prevCounter != null) {
+                    long nanosInSecond = java.util.concurrent.TimeUnit.SECONDS.toNanos(1);
+                    long timeDeltaNanos = curTimeNanos - prevCounter.updateTimeNanos;
+                    if (timeDeltaNanos > nanosInSecond) {
+                        long valPerSecond = (long) ((double) (newCounter.value - prevCounter.value)
+                                * nanosInSecond / timeDeltaNanos);
+                        boolean traceAllCounters = Objects.equals(counters, "")
+                                || Objects.equals(counters, "stdout")
+                                || Objects.equals(counters, "stderr");
+                        boolean traceEnabled = traceAllCounters || (counters != null && counters.contains(counterName));
+                        if (traceEnabled) {
+                            if (counters.contains("stderr")) {
+                                System.err.println(counterName + " per second: " + valPerSecond);
+                            } else {
+                                System.out.println(counterName + " per second: " + valPerSecond);
+                            }
+                        }
+                        if (perfLog.isLoggable(PlatformLogger.Level.FINE)) {
+                            perfLog.fine(counterName + " per second: " + valPerSecond);
+                        }
+                        synchronized (w.perfCountersPrev) {
+                            w.perfCountersPrev.put(counterName, newCounter);
+                        }
+                    }
+                }
+            }
+
+            public long getCounter(Window w, String counterName) {
+                Objects.requireNonNull(w);
+                Objects.requireNonNull(counterName);
+
+                synchronized (w.perfCounters) {
+                    PerfCounter counter = w.perfCounters.get(counterName);
+                    return counter != null ? counter.value : -1L;
+                }
+            }
+
+            public long getCounterPerSecond(Window w, String counterName) {
+                Objects.requireNonNull(w);
+                Objects.requireNonNull(counterName);
+
+                PerfCounter newCounter;
+                PerfCounter prevCounter;
+
+                synchronized (w.perfCounters) {
+                    newCounter = w.perfCounters.get(counterName);
+                }
+
+                synchronized (w.perfCountersPrev) {
+                    prevCounter = w.perfCountersPrev.get(counterName);
+                }
+
+                if (newCounter != null && prevCounter != null) {
+                    long timeDeltaNanos = newCounter.updateTimeNanos - prevCounter.updateTimeNanos;
+                    // Note that this time delta will usually be above one second.
+                    if (timeDeltaNanos > 0) {
+                        long nanosInSecond = java.util.concurrent.TimeUnit.SECONDS.toNanos(1);
+                        long valPerSecond = (long) ((double) (newCounter.value - prevCounter.value)
+                                * nanosInSecond / timeDeltaNanos);
+                        return valPerSecond;
+                    }
+                }
+                return -1;
+            }
         }); // WindowAccessor
     } // static
 
     // a window doesn't need to be updated in the Z-order.
     @Override
     void updateZOrder() {}
+
+    private record PerfCounter(Long updateTimeNanos, Long value) {}
+
+    private transient final Map<String, PerfCounter> perfCounters = new HashMap<>(4);
+    private transient final Map<String, PerfCounter> perfCountersPrev = new HashMap<>(4);
 
 } // class Window
 

--- a/src/java.desktop/share/classes/javax/swing/RepaintManager.java
+++ b/src/java.desktop/share/classes/javax/swing/RepaintManager.java
@@ -49,6 +49,8 @@ import sun.security.action.GetPropertyAction;
 
 import com.sun.java.swing.SwingUtilities3;
 import java.awt.geom.AffineTransform;
+import java.util.stream.Collectors;
+
 import sun.java2d.SunGraphics2D;
 import sun.java2d.pipe.Region;
 import sun.swing.SwingAccessor;
@@ -811,7 +813,14 @@ public class RepaintManager
 
             for (Window window : windows) {
                 AWTAccessor.getWindowAccessor().updateWindow(window);
+                AWTAccessor.getWindowAccessor().bumpCounter(window, "swing.RepaintManager.updateWindows");
             }
+        } else {
+            dirtyComponents.keySet().stream()
+                    .map(c -> c instanceof Window w ? w : SwingUtilities.getWindowAncestor(c))
+                    .filter(Objects::nonNull)
+                    .forEach(w -> AWTAccessor.getWindowAccessor()
+                            .bumpCounter(w, "swing.RepaintManager.updateWindows"));
         }
     }
 

--- a/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
@@ -347,6 +347,7 @@ public final class AWTAccessor {
          */
         Window[] getOwnedWindows(Window w);
 
+        boolean countersEnabled(Window w);
         void bumpCounter(Window w, String counterName);
         long getCounter(Window w, String counterName);
         long getCounterPerSecond(Window w, String counterName);

--- a/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTAccessor.java
@@ -346,6 +346,10 @@ public final class AWTAccessor {
          * window currently owns.
          */
         Window[] getOwnedWindows(Window w);
+
+        void bumpCounter(Window w, String counterName);
+        long getCounter(Window w, String counterName);
+        long getCounterPerSecond(Window w, String counterName);
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/java2d/wl/WLSMSurfaceData.java
+++ b/src/java.desktop/unix/classes/sun/java2d/wl/WLSMSurfaceData.java
@@ -49,14 +49,14 @@ public class WLSMSurfaceData extends SurfaceData implements WLSurfaceDataExt {
 
     public native void assignSurface(long surfacePtr);
 
-    private native void initOps(int width, int height, int scale, int backgroundRGB, int wlShmFormat);
+    private native void initOps(int width, int height, int scale, int backgroundRGB, int wlShmFormat, boolean perfCountersEnabled);
     private static native void initIDs();
 
     static {
         initIDs();
     }
 
-    private WLSMSurfaceData(WLComponentPeer peer, SurfaceType surfaceType, ColorModel colorModel, int scale, int wlShmFormat) {
+    private WLSMSurfaceData(WLComponentPeer peer, SurfaceType surfaceType, ColorModel colorModel, int scale, int wlShmFormat, boolean perfCountersEnabled) {
         super(surfaceType, colorModel);
         this.peer = peer;
 
@@ -71,7 +71,7 @@ public class WLSMSurfaceData extends SurfaceData implements WLSurfaceDataExt {
             log.fine(String.format("Shared memory surface data %dx%d x%d scale, format %d", width, height, scale, wlShmFormat));
         }
 
-        initOps(width, height, scale, backgroundPixel, wlShmFormat);
+        initOps(width, height, scale, backgroundPixel, wlShmFormat, perfCountersEnabled);
     }
 
     /**
@@ -83,7 +83,9 @@ public class WLSMSurfaceData extends SurfaceData implements WLSurfaceDataExt {
         }
         ColorModel cm = graphicsConfig.getColorModel();
         SurfaceType surfaceType = graphicsConfig.getSurfaceType();
-        return new WLSMSurfaceData(peer, surfaceType, cm, graphicsConfig.getWlScale(), graphicsConfig.getWlShmFormat());
+        Window target = peer.getTarget() instanceof Window ? (Window)peer.getTarget() : null;
+        boolean perfCountersEnabled = target != null && AWTAccessor.getWindowAccessor().countersEnabled(target);
+        return new WLSMSurfaceData(peer, surfaceType, cm, graphicsConfig.getWlScale(), graphicsConfig.getWlShmFormat(), perfCountersEnabled);
     }
 
     @Override

--- a/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.c
+++ b/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.c
@@ -88,7 +88,6 @@ AssertDrawLockIsHeld(WLSurfaceBufferManager* manager, const char * file, int lin
 const int MAX_BUFFERS_IN_USE = 2;
 
 static bool traceEnabled;    // set the J2D_STATS env var to enable
-static bool traceFPSEnabled; // set the J2D_FPS env var to enable
 
 /**
  * Represents one rectangular area linked into a list.
@@ -280,6 +279,10 @@ struct WLSurfaceBufferManager {
      * on the screen.
      */
     WLDrawBuffer        bufferForDraw; // only accessed under drawLock
+
+    jobject              surfaceDataWeakRef;
+    FrameCounterCallback frameSentCallback;
+    FrameCounterCallback frameDroppedCallback;
 };
 
 static inline void
@@ -304,7 +307,7 @@ AssertShowLockIsHeld(WLSurfaceBufferManager* manager, const char * file, int lin
 static jlong
 GetJavaTimeNanos(void) {
     jlong result = 0;
-    if (traceEnabled || traceFPSEnabled) {
+    if (traceEnabled) {
         struct timespec tp;
         const jlong NANOSECS_PER_SEC = 1000000000L;
         int status = clock_gettime(CLOCK_MONOTONIC, &tp);
@@ -327,24 +330,6 @@ WLBufferTrace(WLSurfaceBufferManager* manager, const char *fmt, ...)
                 manager->bufferForDraw.frameID);
         fflush(stderr);
         va_end(args);
-    }
-}
-
-static void
-WLBufferTraceFrame(WLSurfaceBufferManager* manager)
-{
-    if (traceFPSEnabled) {
-        static jlong lastFrameTime = 0;
-        static int frameCount = 0;
-
-        jlong curTime = GetJavaTimeNanos();
-        frameCount++;
-        if (curTime - lastFrameTime > 1000000000L) {
-            fprintf(stderr, "FPS: %d\n", frameCount);
-            fflush(stderr);
-            lastFrameTime = curTime;
-            frameCount = 0;
-        }
     }
 }
 
@@ -660,6 +645,10 @@ ShowBufferIsAvailable(WLSurfaceBufferManager * manager)
                 return false; // failed to resize, likely due to OOM
             }
         }
+    } else {
+        if (manager->frameDroppedCallback != NULL) {
+            manager->frameDroppedCallback(manager->surfaceDataWeakRef);
+        }
     }
 
     return canSendMoreBuffers;
@@ -785,7 +774,9 @@ SendShowBufferToWayland(WLSurfaceBufferManager * manager)
 
     jlong endTime = GetJavaTimeNanos();
     WLBufferTrace(manager, "SendShowBufferToWayland (%lldns)", endTime - startTime);
-    WLBufferTraceFrame(manager);
+    if (manager->frameSentCallback != NULL) {
+        manager->frameSentCallback(manager->surfaceDataWeakRef);
+    }
 }
 
 static void
@@ -934,10 +925,16 @@ HaveEnoughMemoryForWindow(jint width, jint height)
 }
 
 WLSurfaceBufferManager *
-WLSBM_Create(jint width, jint height, jint scale, jint bgPixel, jint wlShmFormat)
+WLSBM_Create(jint width,
+             jint height,
+             jint scale,
+             jint bgPixel,
+             jint wlShmFormat,
+             jobject surfaceDataWeakRef,
+             FrameCounterCallback frameSentCallback,
+             FrameCounterCallback frameDroppedCallback)
 {
     traceEnabled = getenv("J2D_STATS");
-    traceFPSEnabled = getenv("J2D_FPS");
 
     if (!HaveEnoughMemoryForWindow(width, height)) {
        return NULL;
@@ -953,6 +950,9 @@ WLSBM_Create(jint width, jint height, jint scale, jint bgPixel, jint wlShmFormat
     manager->scale = scale;
     manager->bgPixel = bgPixel;
     manager->format = wlShmFormat;
+    manager->surfaceDataWeakRef = surfaceDataWeakRef;
+    manager->frameSentCallback = frameSentCallback;
+    manager->frameDroppedCallback = frameDroppedCallback;
 
     pthread_mutex_init(&manager->showLock, NULL);
 
@@ -995,6 +995,9 @@ void
 WLSBM_Destroy(WLSurfaceBufferManager * manager)
 {
     J2dTrace1(J2D_TRACE_INFO, "WLSBM_Destroy: manger %p\n", manager);
+
+    JNIEnv* env = getEnv();
+    (*env)->DeleteWeakGlobalRef(env, manager->surfaceDataWeakRef);
 
     // NB: must never be called in parallel with the Wayland event handlers
     // because their callbacks retain a pointer to this manager.

--- a/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.h
+++ b/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.h
@@ -48,6 +48,8 @@ typedef struct WLDrawBuffer WLDrawBuffer;
  */
 typedef uint32_t pixel_t;
 
+typedef void (*FrameCounterCallback)(jobject);
+
 /**
  * Create a WayLand Surface Buffer Manager for a surface of size width x height
  * pixels with the given background 32-bit pixel value and wl_shm_format.
@@ -61,7 +63,10 @@ typedef uint32_t pixel_t;
  * the drawing to displaying buffer, synchronization, and sending
  * the appropriate notifications to Wayland.
  */
-WLSurfaceBufferManager * WLSBM_Create(jint width, jint height, jint scale, jint bgPixel, jint wlShmFormat);
+WLSurfaceBufferManager * WLSBM_Create(jint width, jint height, jint scale, jint bgPixel, jint wlShmFormat,
+                                      jobject surfaceDataWeakRef,
+                                      FrameCounterCallback frameSentCallback,
+                                      FrameCounterCallback frameDroppedCallback);
 
 /**
  * Free all resources allocated for the WayLand Surface Buffer Manager,

--- a/src/java.desktop/unix/native/common/java2d/wl/WLSMSurfaceData.c
+++ b/src/java.desktop/unix/native/common/java2d/wl/WLSMSurfaceData.c
@@ -365,7 +365,8 @@ Java_sun_java2d_wl_WLSMSurfaceData_initOps(JNIEnv *env, jobject wsd,
                                            jint height,
                                            jint scale,
                                            jint backgroundRGB,
-                                           jint wlShmFormat)
+                                           jint wlShmFormat,
+                                           jboolean perfCountersEnabled)
 {
 #ifndef HEADLESS
 
@@ -393,7 +394,9 @@ Java_sun_java2d_wl_WLSMSurfaceData_initOps(JNIEnv *env, jobject wsd,
     wsdo->sdOps.GetRasInfo = WLSD_GetRasInfo;
     wsdo->sdOps.Dispose = WLSD_Dispose;
     wsdo->bufferManager = WLSBM_Create(width, height, scale, backgroundRGB, wlShmFormat,
-                                       surfaceDataWeakRef, CountFrameSent, CountFrameDropped);
+                                       surfaceDataWeakRef,
+                                       perfCountersEnabled ? CountFrameSent : NULL,
+                                       perfCountersEnabled ? CountFrameDropped : NULL);
     if (wsdo->bufferManager == NULL) {
         JNU_ThrowOutOfMemoryError(env, "Failed to create Wayland surface buffer manager");
         return;

--- a/src/java.desktop/unix/native/common/java2d/wl/WLSMSurfaceData.c
+++ b/src/java.desktop/unix/native/common/java2d/wl/WLSMSurfaceData.c
@@ -36,6 +36,7 @@
 #include "Trace.h"
 #include "WLSMSurfaceData.h"
 #include "WLBuffers.h"
+#include "WLToolkit.h"
 
 struct WLSDOps {
     SurfaceDataOps      sdOps;
@@ -62,6 +63,18 @@ typedef struct WLSDPrivate {
     jint           lockFlags;
     WLDrawBuffer * wlBuffer;
 } WLSDPrivate;
+
+static jmethodID countNewFrameMID;
+static jmethodID countDroppedFrameMID;
+
+JNIEXPORT void JNICALL
+Java_sun_java2d_wl_WLSMSurfaceData_initIDs
+        (JNIEnv *env, jclass clazz)
+{
+    // NB: don't care if those "count" methods are found.
+    countNewFrameMID = (*env)->GetMethodID(env, clazz, "countNewFrame", "()V");
+    countDroppedFrameMID = (*env)->GetMethodID(env, clazz, "countDroppedFrame", "()V");
+}
 
 JNIEXPORT WLSDOps * JNICALL
 WLSMSurfaceData_GetOps(JNIEnv *env, jobject sData)
@@ -313,6 +326,34 @@ WLSD_Dispose(JNIEnv *env, SurfaceDataOps *ops)
 #endif
 }
 
+static void
+CountFrameSent(jobject surfaceDataWeakRef)
+{
+    if (countNewFrameMID != NULL) {
+        JNIEnv *env = getEnv();
+        const jobject surfaceData = (*env)->NewLocalRef(env, surfaceDataWeakRef);
+        if (surfaceData != NULL) {
+            (*env)->CallVoidMethod(env, surfaceData, countNewFrameMID);
+            (*env)->DeleteLocalRef(env, surfaceData);
+            JNU_CHECK_EXCEPTION(env);
+        }
+    }
+}
+
+static void
+CountFrameDropped(jobject surfaceDataWeakRef)
+{
+    if (countDroppedFrameMID != NULL) {
+        JNIEnv *env = getEnv();
+        const jobject surfaceData = (*env)->NewLocalRef(env, surfaceDataWeakRef);
+        if (surfaceData != NULL) {
+            (*env)->CallVoidMethod(env, surfaceData, countDroppedFrameMID);
+            (*env)->DeleteLocalRef(env, surfaceData);
+            JNU_CHECK_EXCEPTION(env);
+        }
+    }
+}
+
 /*
  * Class:     sun_java2d_wl_WLSMSurfaceData
  * Method:    initOps
@@ -343,11 +384,16 @@ Java_sun_java2d_wl_WLSMSurfaceData_initOps(JNIEnv *env, jobject wsd,
         height = 1;
     }
 
+    jobject surfaceDataWeakRef = NULL;
+    surfaceDataWeakRef = (*env)->NewWeakGlobalRef(env, wsd);
+    JNU_CHECK_EXCEPTION(env);
+
     wsdo->sdOps.Lock = WLSD_Lock;
     wsdo->sdOps.Unlock = WLSD_Unlock;
     wsdo->sdOps.GetRasInfo = WLSD_GetRasInfo;
     wsdo->sdOps.Dispose = WLSD_Dispose;
-    wsdo->bufferManager = WLSBM_Create(width, height, scale, backgroundRGB, wlShmFormat);
+    wsdo->bufferManager = WLSBM_Create(width, height, scale, backgroundRGB, wlShmFormat,
+                                       surfaceDataWeakRef, CountFrameSent, CountFrameDropped);
     if (wsdo->bufferManager == NULL) {
         JNU_ThrowOutOfMemoryError(env, "Failed to create Wayland surface buffer manager");
         return;

--- a/test/jdk/jb/java/awt/Counters/UpdateWindowsCounter.java
+++ b/test/jdk/jb/java/awt/Counters/UpdateWindowsCounter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * @test
+ * @summary Verifies that swing.RepaintManager.updateWindows performance counter gets
+ *          updated for a Swing application
+ * @key headful
+ * @library /test/lib
+ * @run main UpdateWindowsCounter
+ */
+
+public class UpdateWindowsCounter {
+    private static int counter = 25;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0) {
+            runSwingApp();
+        } else {
+            runOneTest("-Dawt.window.counters=stdout", "swing.RepaintManager.updateWindows per second");
+            runOneTest("-Dawt.window.counters=swing.RepaintManager.updateWindows,stdout", "swing.RepaintManager.updateWindows per second");
+            runOneTest("-Dawt.window.counters=stderr,swing.RepaintManager.updateWindows", "swing.RepaintManager.updateWindows per second");
+            runOneTest("-Dawt.window.counters", "swing.RepaintManager.updateWindows per second");
+            runOneTest("-Dawt.window.counters=", "swing.RepaintManager.updateWindows per second");
+            runOneTest("-Dawt.window.counters=swing.RepaintManager.updateWindows", "swing.RepaintManager.updateWindows per second");
+
+            runOneNegativeTest("", "swing.RepaintManager.updateWindows");
+            runOneNegativeTest("-Dawt.window.counters=UNCOUNTABLE", "swing.RepaintManager.updateWindows");
+        }
+    }
+
+    private static void runOneTest(String vmArg, String expectedOutput) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(vmArg,
+                UpdateWindowsCounter.class.getName(),
+                "test");
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain(expectedOutput);
+    }
+
+    private static void runOneNegativeTest(String vmArg, String unexpectedOutput) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(vmArg,
+                UpdateWindowsCounter.class.getName(),
+                "test");
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotContain(unexpectedOutput);
+    }
+
+    private static void runSwingApp() {
+        SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("Timer App");
+            frame.setSize(300, 200);
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+            JLabel label = new JLabel("---", SwingConstants.CENTER);
+            frame.getContentPane().add(label);
+
+            Timer timer = new Timer(100, new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    counter--;
+                    label.setText(String.valueOf(counter));
+
+                    if (counter == 0) {
+                        ((Timer) e.getSource()).stop();
+                        frame.dispose();
+                    }
+                }
+            });
+
+            frame.setVisible(true);
+            timer.start();
+        });
+    }
+}

--- a/test/jdk/jb/java/awt/Counters/WaylandCounters.java
+++ b/test/jdk/jb/java/awt/Counters/WaylandCounters.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * @test
+ * @summary Verifies that java2d.native.frames performance counter gets
+ *          updated for a Swing application running on Wayland
+ * @key headful
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @run main WaylandCounters
+ */
+
+public class WaylandCounters {
+    private static int counter = 25;
+
+    public static void main(String[] args) throws Exception {
+        Toolkit tk = Toolkit.getDefaultToolkit();
+        if (!tk.getClass().getName().equals("sun.awt.wl.WLToolkit")) return;
+
+        if (args.length > 0) {
+            runSwingApp();
+        } else {
+            {
+                ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Dawt.window.counters=stderr",
+                        UpdateWindowsCounter.class.getName(),
+                        "test");
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.stderrShouldContain("java2d.native.frames per second");
+                output.stdoutShouldBeEmpty();
+            }
+
+            {
+                ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Dawt.window.counters=java2d.native.frames,stdout",
+                        UpdateWindowsCounter.class.getName(),
+                        "test");
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.stdoutShouldContain("java2d.native.frames per second");
+                output.stdoutShouldNotContain("swing.RepaintManager.updateWindows");
+                output.stderrShouldBeEmpty();
+            }
+
+            {
+                ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Dawt.window.counters=stderr,java2d.native.frames",
+                        UpdateWindowsCounter.class.getName(),
+                        "test");
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.stderrShouldContain("java2d.native.frames per second");
+                output.stderrShouldNotContain("swing.RepaintManager.updateWindows");
+                output.stdoutShouldBeEmpty();
+            }
+
+            {
+                ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Dawt.window.counters=stdout",
+                        UpdateWindowsCounter.class.getName(),
+                        "test");
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.stderrShouldBeEmpty();
+                output.shouldContain("java2d.native.frames per second");
+            }
+
+            {
+                ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Dawt.window.counters=java2d.native.frames",
+                        UpdateWindowsCounter.class.getName(),
+                        "test");
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.stdoutShouldContain("java2d.native.frames per second");
+                output.stdoutShouldNotContain("swing.RepaintManager.updateWindows");
+                output.stderrShouldBeEmpty();
+            }
+
+        }
+    }
+
+    private static void runSwingApp() {
+        SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("Timer App");
+            frame.setSize(300, 200);
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+            JLabel label = new JLabel("---", SwingConstants.CENTER);
+            frame.getContentPane().add(label);
+
+            Timer timer = new Timer(100, new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    counter--;
+                    label.setText(String.valueOf(counter));
+
+                    if (counter == 0) {
+                        ((Timer) e.getSource()).stop();
+                        frame.dispose();
+                    }
+                }
+            });
+
+            frame.setVisible(true);
+            timer.start();
+        });
+    }
+}


### PR DESCRIPTION
[JBR-7028](https://youtrack.jetbrains.com/issue/JBR-7028) Implement FPS counter on Linux

Please review this from the point of view of usability both on the provider and the supplier side. We will add JBRApi for external access in a separate commit.

I suggest that those toolkits that can provide more or less reliable hardware FPS use the same counter name; here, it is `java2d.native.frames`, but any other will do as well.