### PR TITLE
JBR-5611 Window header is visible but body not on Linux Ubuntu with external display

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -1215,7 +1215,9 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
         }
         X11GraphicsDevice x11gd = (X11GraphicsDevice) gd;
         int screenNum = x11gd.getScreen();
-        if (localEnv.runningXinerama() && screenNum != 0) {
+        Rectangle screen = gc.getBounds();
+        boolean isFirstScreen = screen.x == 0 && screen.y == 0;
+        if (localEnv.runningXinerama() && !isFirstScreen) {
             // We cannot estimate insets for non-default screen,
             // there are often none.
             return new Insets(0, 0, 0, 0);
@@ -1224,7 +1226,6 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
         XToolkit.awtLock();
         try {
             Rectangle workArea = getWorkArea(XlibUtil.getRootWindow(screenNum));
-            Rectangle screen = gc.getBounds();
             if (workArea != null) {
                 Point p = x11gd.scaleDown(workArea.x, workArea.y);
                 workArea.x = p.x;
@@ -1233,8 +1234,8 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
                 workArea.height = x11gd.scaleDown(workArea.height);
                 workArea = workArea.intersection(screen);
                 if (!workArea.isEmpty()) {
-                    int top = workArea.y - screen.y;
-                    int left = workArea.x - screen.x;
+                    int top = workArea.y;
+                    int left = workArea.x;
                     int bottom = screen.height - workArea.height - top;
                     int right = screen.width - workArea.width - left;
                     return new Insets(top, left, bottom, right);


### PR DESCRIPTION
[JBR-5611](https://youtrack.jetbrains.com/issue/JBR-5611) Window header is visible but body not on Linux Ubuntu with external display

In general, we cannot estimate insets when there's more than one monitor except for the "first" monitor, the one at the top left of the whole setup.

Consider a two-screen setup where screens are on top of one another. The topmost screen with a status bar at the top and a dock at the bottom of the other screen that is at the bottom. One has the scale of 1.5x and the other 1.25x. So the overall height in the user space will be
`(status-bar-height + free-area-1-height)/1.5 + (free-area-2-height + dock-height)/1.25`.
`_NET_WORKAREA` gives us this value when in xinerama mode. `GraphicsConfiguration.getBounds()` gives us the individual
expressions (`(status-bar-height + free-area-1-height)` and `(free-area-2-height + dock-height)`). Then we need to calculate, for example, `free-area-1-height`. This is a system of equations with 4 variables that has no solution.

The previous assumption in the code that we can reliably calculate insets for the default screen is incorrect because the default screen in terms of Xinerama does not have to be the one at the top left. So this fix clarifies this assumption. Only the top left monitor in a multi-monitor configuration will get real insets; other monitors will have 0 insets.
