### PR TITLE
JBR-7202 wayland: memory leak when resizing windows

### DIFF
--- a/src/java.desktop/unix/classes/sun/java2d/wl/WLVolatileSurfaceManager.java
+++ b/src/java.desktop/unix/classes/sun/java2d/wl/WLVolatileSurfaceManager.java
@@ -26,25 +26,19 @@
 
 package sun.java2d.wl;
 
-import java.awt.Component;
 import java.awt.GraphicsConfiguration;
 import java.awt.ImageCapabilities;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
+import java.awt.geom.AffineTransform;
+import java.awt.image.VolatileImage;
+import java.util.Objects;
 
 import sun.awt.image.SunVolatileImage;
 import sun.awt.image.VolatileSurfaceManager;
 import sun.java2d.SurfaceData;
 
-public class WLVolatileSurfaceManager extends VolatileSurfaceManager implements PropertyChangeListener {
-    private static final String SCALE_PROPERTY_NAME = "graphicsContextScaleTransform";
-
+public class WLVolatileSurfaceManager extends VolatileSurfaceManager {
     public WLVolatileSurfaceManager(SunVolatileImage vImg, Object context) {
         super(vImg, context);
-        Component component = vImg.getComponent();
-        if (component != null) {
-            component.addPropertyChangeListener(SCALE_PROPERTY_NAME, this);
-        }
     }
 
     protected boolean isAccelerationEnabled() {
@@ -63,9 +57,12 @@ public class WLVolatileSurfaceManager extends VolatileSurfaceManager implements 
     }
 
     @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-        assert SCALE_PROPERTY_NAME.equals(evt.getPropertyName());
-
-        displayChanged();
+    public int validate(GraphicsConfiguration gc) {
+        AffineTransform newTx = gc.getDefaultTransform();
+        if (!Objects.equals(atCurrent, newTx)) {
+            // May need a different size on another display
+            return VolatileImage.IMAGE_INCOMPATIBLE;
+        }
+        return super.validate(gc);
     }
 }


### PR DESCRIPTION
[JBR-7202](https://youtrack.jetbrains.com/issue/JBR-7202) wayland: memory leak when resizing windows

Instead of relying on the property change event, it is enough to signal `IMAGE_INCOMPATIBLE` when this surface manager gets validated against a graphics configuration with a different transform. This will result in "invalid" buffers dropped by the component's repaint manager and new buffers created with no references that prevent garbage collection.