### PR TITLE
JBR-7237 Separate display connect from WLToolkit initialization

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLDisplay.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLDisplay.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.awt.wl;
+
+import java.awt.AWTError;
+
+public final class WLDisplay {
+    private static final WLDisplay INSTANCE = new WLDisplay();
+
+    private final long displayPtr;
+
+    private WLDisplay() {
+        long p = connect(); // NB: we never disconnect
+        if (p == 0) {
+            throw new AWTError("Can't connect to the Wayland server");
+        }
+
+        displayPtr = p;
+    }
+
+    public long getDisplayPtr() {
+        return displayPtr;
+    }
+
+    public static WLDisplay getInstance() {
+        return INSTANCE;
+    }
+
+    private native long connect();
+}

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLToolkit.java
@@ -36,6 +36,7 @@ import sun.awt.PeerEvent;
 import sun.awt.SunToolkit;
 import sun.awt.UNIXToolkit;
 import sun.awt.datatransfer.DataTransferer;
+import sun.awt.wl.WLDisplay;
 import sun.util.logging.PlatformLogger;
 
 import java.awt.*;
@@ -137,12 +138,12 @@ public class WLToolkit extends UNIXToolkit implements Runnable {
     private final WLClipboard clipboard;
     private final WLClipboard selection;
 
-    private static native void initIDs();
+    private static native void initIDs(long displayPtr);
 
     static {
         if (!GraphicsEnvironment.isHeadless()) {
             keyboard = new WLKeyboard();
-            initIDs();
+            initIDs(WLDisplay.getInstance().getDisplayPtr());
         }
         initialized = true;
     }

--- a/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
+++ b/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
@@ -48,6 +48,7 @@
 #include "JNIUtilities.h"
 #include "awt.h"
 #include "sun_awt_wl_WLToolkit.h"
+#include "sun_awt_wl_WLDisplay.h"
 #include "WLRobotPeer.h"
 #include "WLGraphicsEnvironment.h"
 #include "memory_utils.h"
@@ -736,16 +737,17 @@ finalizeInit(JNIEnv *env) {
     }
 }
 
-JNIEXPORT void JNICALL
-Java_sun_awt_wl_WLToolkit_initIDs
-  (JNIEnv *env, jclass clazz)
+JNIEXPORT jlong JNICALL
+Java_sun_awt_wl_WLDisplay_connect(JNIEnv *env, jobject obj)
 {
-    wl_display = wl_display_connect(NULL);
-    if (!wl_display) {
-        J2dTrace(J2D_TRACE_ERROR, "WLToolkit: Failed to connect to Wayland display\n");
-        JNU_ThrowByName(env, "java/awt/AWTError", "Can't connect to the Wayland server");
-        return;
-    }
+    return ptr_to_jlong(wl_display_connect(NULL));
+}
+
+JNIEXPORT void JNICALL
+Java_sun_awt_wl_WLToolkit_initIDs(JNIEnv *env, jclass clazz, jlong displayPtr)
+{
+    assert (displayPtr != 0);
+    wl_display = jlong_to_ptr(displayPtr);
 
     if (!initJavaRefs(env, clazz)) {
         JNU_ThrowInternalError(env, "Failed to find Wayland toolkit internal classes");


### PR DESCRIPTION
[JBR-7237](https://youtrack.jetbrains.com/issue/JBR-7237) Fix circular dependency of Wayland and Vulkan initialization

