### PR TITLE
JBR-7245 DCEVM: Fix multiple class modification at breakpoint

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -2865,7 +2865,7 @@ JvmtiEnv::GetMethodName(Method* method, char** name_ptr, char** signature_ptr, c
 jvmtiError
 JvmtiEnv::GetMethodDeclaringClass(Method* method, jclass* declaring_class_ptr) {
   NULL_CHECK(method, JVMTI_ERROR_INVALID_METHODID);
-  (*declaring_class_ptr) = get_jni_class_non_null(method->method_holder());
+  (*declaring_class_ptr) = get_jni_class_non_null(method->method_holder()->newest_version());
   return JVMTI_ERROR_NONE;
 } /* end GetMethodDeclaringClass */
 


### PR DESCRIPTION
If an application is paused at a breakpoint in method M of class C and method M is modified N times, each modification triggers N redefinitions of class C. This patch fixes this bug.