### PR TITLE
JBR-7351 DCEVM: Respect explicit -XX:+ClassUnloading option

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4021,7 +4021,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
 
   setup_hotswap_agent();
 
-  if (AllowEnhancedClassRedefinition) {
+  if (AllowEnhancedClassRedefinition && !FLAG_IS_CMDLINE(ClassUnloading)) {
     ClassUnloading = false;
     ClassUnloadingWithConcurrentMark = false;
   }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4021,9 +4021,13 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
 
   setup_hotswap_agent();
 
-  if (AllowEnhancedClassRedefinition && !FLAG_IS_CMDLINE(ClassUnloading)) {
-    ClassUnloading = false;
-    ClassUnloadingWithConcurrentMark = false;
+  if (AllowEnhancedClassRedefinition) {
+    if (!FLAG_IS_CMDLINE(ClassUnloading)) {
+      ClassUnloading = false;
+      ClassUnloadingWithConcurrentMark = false;
+    } else {
+      warning("The JVM is unstable when using -XX:+AllowEnhancedClassRedefinition and -XX:+ClassUnloading together!");
+    }
   }
 
 #if !INCLUDE_CDS


### PR DESCRIPTION
Ensure that ClassUnloading is not disabled if the -XX:+ClassUnloading flag is explicitly set by the user.