### PR TITLE
JBR-7392: Use NIO FS in ZipFile

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -26,17 +26,22 @@
 package java.util.zip;
 
 import java.io.Closeable;
-import java.io.InputStream;
-import java.io.IOException;
 import java.io.EOFException;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
 import java.lang.ref.Cleaner.Cleanable;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
-import java.nio.file.InvalidPathException;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,6 +72,7 @@ import jdk.internal.util.OperatingSystem;
 import jdk.internal.perf.PerfCounter;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.vm.annotation.Stable;
+import sun.nio.ch.FileChannelImpl;
 import sun.nio.cs.UTF_8;
 import sun.nio.fs.DefaultFileSystemProvider;
 import sun.security.action.GetPropertyAction;
@@ -105,6 +111,9 @@ public class ZipFile implements ZipConstants, Closeable {
     // b) the list of cached Inflater objects
     // c) the "native" source of this ZIP file.
     private final @Stable CleanableResource res;
+
+    private static final boolean USE_NIO_FOR_ZIP_FILE_ACCESS =
+        Boolean.parseBoolean(System.getProperty("java.util.zip.use.nio.for.zip.file.access", "false"));
 
     private static final int STORED = ZipEntry.STORED;
     private static final int DEFLATED = ZipEntry.DEFLATED;
@@ -1190,7 +1199,7 @@ public class ZipFile implements ZipConstants, Closeable {
 
         private int refs = 1;
 
-        private RandomAccessFile zfile;      // zfile of the underlying ZIP file
+        private FileAccessor zfile;          // zfile of the underlying ZIP file
         private byte[] cen;                  // CEN & ENDHDR
         private long locpos;                 // position of first LOC header (usually 0)
         private byte[] comment;              // ZIP file comment
@@ -1200,6 +1209,88 @@ public class ZipFile implements ZipConstants, Closeable {
         private int[] signatureMetaNames;    // positions of signature related entries, if such exist
         private int[] metaVersions;          // list of unique versions found in META-INF/versions/
         private final boolean startsWithLoc; // true, if ZIP file starts with LOCSIG (usually true)
+
+        private interface FileAccessor {
+            long length() throws IOException;
+            int read(byte[] dst, int off, int len) throws IOException;
+            void readFully(byte[] dst, int off, int len) throws IOException;
+            void seek(long pos) throws IOException;
+            void close() throws IOException;
+        }
+
+        static class RandomAccessFileAccessor implements FileAccessor {
+            private final RandomAccessFile file;
+
+            RandomAccessFileAccessor(RandomAccessFile file) {
+                this.file = file;
+            }
+
+            @Override
+            public long length() throws IOException {
+                return file.length();
+            }
+
+            @Override
+            public int read(byte[] dst, int off, int len) throws IOException {
+                return file.read(dst, off, len);
+            }
+
+            @Override
+            public void readFully(byte[] dst, int off, int len) throws IOException {
+                file.readFully(dst, off, len);
+            }
+
+            @Override
+            public void seek(long pos) throws IOException {
+                file.seek(pos);
+            }
+
+            @Override
+            public void close() throws IOException {
+                file.close();
+            }
+        }
+
+        static class ChannelFileAccessor implements FileAccessor {
+            private final FileChannel channel;
+
+            ChannelFileAccessor(FileChannel file) {
+                this.channel = file;
+            }
+
+            @Override
+            public long length() throws IOException {
+                return channel.size();
+            }
+
+            @Override
+            public int read(byte[] dst, int off, int len) throws IOException {
+                ByteBuffer buf = ByteBuffer.wrap(dst, off, len);
+                return channel.read(buf);
+            }
+
+            @Override
+            public void readFully(byte[] dst, int off, int len) throws IOException {
+                // copy-pasted from java.io.RandomAccessFile.readFully(byte[], int, int)
+                int n = 0;
+                do {
+                    int count = this.read(dst, off + n, len - n);
+                    if (count < 0)
+                        throw new EOFException();
+                    n += count;
+                } while (n < len);
+            }
+
+            @Override
+            public void seek(long pos) throws IOException {
+                channel.position(pos);
+            }
+
+            @Override
+            public void close() throws IOException {
+                channel.close();
+            }
+        }
 
         // A Hashmap for all entries.
         //
@@ -1547,16 +1638,32 @@ public class ZipFile implements ZipConstants, Closeable {
         private Source(Key key, boolean toDelete, ZipCoder zc) throws IOException {
             this.zc = zc;
             this.key = key;
-            if (toDelete) {
-                if (OperatingSystem.isWindows()) {
-                    this.zfile = SharedSecrets.getJavaIORandomAccessFileAccess()
-                                              .openAndDelete(key.file, "r");
+            if (USE_NIO_FOR_ZIP_FILE_ACCESS) {
+                Set<OpenOption> options;
+                if (toDelete) {
+                    options = Set.of(StandardOpenOption.READ, StandardOpenOption.DELETE_ON_CLOSE);
                 } else {
-                    this.zfile = new RandomAccessFile(key.file, "r");
-                    key.file.delete();
+                    options = Set.of(StandardOpenOption.READ);
                 }
+                FileChannel channel = FileSystems.getDefault().provider().newFileChannel(key.file.toPath(), options);
+                if (channel instanceof FileChannelImpl) {
+                    ((FileChannelImpl) channel).setUninterruptible();
+                }
+                this.zfile = new ChannelFileAccessor(channel);
             } else {
-                this.zfile = new RandomAccessFile(key.file, "r");
+                RandomAccessFile file;
+                if (toDelete) {
+                    if (OperatingSystem.isWindows()) {
+                        file = SharedSecrets.getJavaIORandomAccessFileAccess()
+                                .openAndDelete(key.file, "r");
+                    } else {
+                        file = new RandomAccessFile(key.file, "r");
+                        key.file.delete();
+                    }
+                } else {
+                    file = new RandomAccessFile(key.file, "r");
+                }
+                this.zfile = new RandomAccessFileAccessor(file);
             }
             try {
                 initCEN(-1);

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClass.java
@@ -109,7 +109,7 @@ public class RedefineSharedClass {
         // When run without arguments this class acts as the test. First redefining
         // a class that we expect to be in the archive if used and the triggering a
         // System.gc() to clean up.
-        RedefineClassHelper.redefineClass(java.io.RandomAccessFile.class, getClassBytes(java.io.RandomAccessFile.class));
+        RedefineClassHelper.redefineClass(java.util.zip.ZipFile.class, getClassBytes(java.util.zip.ZipFile.class));
         System.gc();
     }
 

--- a/test/jdk/java/nio/Buffer/LimitDirectMemory.java
+++ b/test/jdk/java/nio/Buffer/LimitDirectMemory.java
@@ -29,24 +29,24 @@
  * @library /test/lib
  *
  * @summary Test: memory is properly limited using multiple buffers
- * @run main/othervm -XX:MaxDirectMemorySize=10 LimitDirectMemory true 10 1
- * @run main/othervm -XX:MaxDirectMemorySize=1k LimitDirectMemory true 1k 100
- * @run main/othervm -XX:MaxDirectMemorySize=10m LimitDirectMemory true 10m 10m
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -XX:MaxDirectMemorySize=10 LimitDirectMemory true 10 1
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -XX:MaxDirectMemorySize=1k LimitDirectMemory true 1k 100
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -XX:MaxDirectMemorySize=10m LimitDirectMemory true 10m 10m
  *
  * @summary Test: We can increase the amount of available memory
- * @run main/othervm -XX:MaxDirectMemorySize=65M LimitDirectMemory false 64M 65M
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -XX:MaxDirectMemorySize=65M LimitDirectMemory false 64M 65M
  *
  * @summary Test: Exactly the default amount of memory is available
  * @run main/othervm LimitDirectMemory false 10 1
- * @run main/othervm -Xmx64m LimitDirectMemory false 0 DEFAULT
- * @run main/othervm -Xmx64m LimitDirectMemory true 0 DEFAULT+1
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -Xmx64m LimitDirectMemory false 0 DEFAULT
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -Xmx64m LimitDirectMemory true 0 DEFAULT+1
  *
  * @summary Test: We should be able to eliminate direct memory allocation entirely
- * @run main/othervm -XX:MaxDirectMemorySize=0 LimitDirectMemory true 0 1
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -XX:MaxDirectMemorySize=0 LimitDirectMemory true 0 1
  *
  * @summary Test: Setting the system property should not work so we should be able
  *                to allocate the default amount
- * @run main/othervm -Dsun.nio.MaxDirectMemorySize=1K -Xmx64m
+ * @run main/othervm -Djava.util.zip.use.nio.for.zip.file.access=false -Dsun.nio.MaxDirectMemorySize=1K -Xmx64m
  *                   LimitDirectMemory false DEFAULT-1 DEFAULT/2
  */
 

--- a/test/jdk/java/util/zip/TestZipError.java
+++ b/test/jdk/java/util/zip/TestZipError.java
@@ -63,13 +63,10 @@ public class TestZipError {
         // directory into in-memory data structures.
         ZipFile zf = new ZipFile(fileName);
 
-        // Delete the file; of course this does not change the in-memory data
-        // structures that represent the central directory!
-        f.delete();
-
         // Re-create zip file, with different entries than earlier.  However,
         // recall that we have in-memory information about the central
         // directory of the file at its previous state.
+        // The actual file here is overwritten
         zos = new ZipOutputStream(new FileOutputStream(f));
         ze = new ZipEntry("uno");
         zos.putNextEntry(ze);


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/JBR-7392/Allow-using-NIO-in-ZipFile for discussion.

Tests against upstream JDK: https://github.com/knisht/jdk/pull/1
Tests with enabled property: https://github.com/knisht/jdk/pull/2. It contains an additional failure of `RedefineSharedClass`, which is fixable. 