### PR TITLE
JBR-7466 Exception on VM startup with `-Djava.util.zip.use.nio.for.zip.file.access=true`

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -114,7 +114,7 @@ public class ZipFile implements ZipConstants, Closeable {
     private final @Stable CleanableResource res;
 
     private static final boolean USE_NIO_FOR_ZIP_FILE_ACCESS =
-        Boolean.parseBoolean(System.getProperty("java.util.zip.use.nio.for.zip.file.access", "false"));
+        Boolean.parseBoolean(GetPropertyAction.privilegedGetProperty("java.util.zip.use.nio.for.zip.file.access", "false"));
 
     private static final int STORED = ZipEntry.STORED;
     private static final int DEFLATED = ZipEntry.DEFLATED;

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -68,6 +68,7 @@ import java.util.stream.StreamSupport;
 import jdk.internal.access.JavaUtilZipFileAccess;
 import jdk.internal.access.JavaUtilJarAccess;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.misc.VM;
 import jdk.internal.util.OperatingSystem;
 import jdk.internal.perf.PerfCounter;
 import jdk.internal.ref.CleanerFactory;
@@ -1638,7 +1639,7 @@ public class ZipFile implements ZipConstants, Closeable {
         private Source(Key key, boolean toDelete, ZipCoder zc) throws IOException {
             this.zc = zc;
             this.key = key;
-            if (USE_NIO_FOR_ZIP_FILE_ACCESS) {
+            if (USE_NIO_FOR_ZIP_FILE_ACCESS && VM.isBooted()) {
                 Set<OpenOption> options;
                 if (toDelete) {
                     options = Set.of(StandardOpenOption.READ, StandardOpenOption.DELETE_ON_CLOSE);


### PR DESCRIPTION
[JBR-7466](https://youtrack.jetbrains.com/issue/JBR-7466) Exception on VM startup with `-Djava.util.zip.use.nio.for.zip.file.access=true`

Follow-up for #413 : I encountered an exception during VM startup https://youtrack.jetbrains.com/issue/JBR-7392/Allow-using-NIO-in-ZipFile#focus=Comments-27-10185488.0-0 .