### PR TITLE
[JVM Crash] Remove AllowEnhancedClassRedefinition capability override

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2852,7 +2852,7 @@ static const intArray* sort_methods(Array<Method*>* methods) {
   // We temporarily use the vtable_index field in the Method* to store the
   // class file index, so we can read in after calling qsort.
   // Put the method ordering in the shared archive.
-  if (JvmtiExport::can_maintain_original_method_order() || Arguments::is_dumping_archive()) {
+  if (AllowEnhancedClassRedefinition || JvmtiExport::can_maintain_original_method_order() || Arguments::is_dumping_archive()) {
     for (int index = 0; index < length; index++) {
       Method* const m = methods->at(index);
       assert(!m->valid_vtable_index(), "vtable index should not be set");
@@ -2866,7 +2866,7 @@ static const intArray* sort_methods(Array<Method*>* methods) {
   intArray* method_ordering = nullptr;
   // If JVMTI original method ordering or sharing is enabled construct int
   // array remembering the original ordering
-  if (JvmtiExport::can_maintain_original_method_order() || Arguments::is_dumping_archive()) {
+  if (AllowEnhancedClassRedefinition || JvmtiExport::can_maintain_original_method_order() || Arguments::is_dumping_archive()) {
     method_ordering = new intArray(length, length, -1);
     for (int index = 0; index < length; index++) {
       Method* const m = methods->at(index);

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -1079,7 +1079,7 @@ static void merge_in_new_methods(InstanceKlass* klass,
       klass->class_loader_data(), new_size, nullptr, CHECK);
 
   // original_ordering might be empty if this class has no methods of its own
-  if (JvmtiExport::can_maintain_original_method_order() || Arguments::is_dumping_archive()) {
+  if (AllowEnhancedClassRedefinition || JvmtiExport::can_maintain_original_method_order() || Arguments::is_dumping_archive()) {
     merged_ordering = MetadataFactory::new_array<int>(
         klass->class_loader_data(), new_size, CHECK);
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -4085,7 +4085,7 @@ void InstanceKlass::verify_on(outputStream* st) {
   if (method_ordering() != nullptr) {
     Array<int>* method_ordering = this->method_ordering();
     int length = method_ordering->length();
-    if (JvmtiExport::can_maintain_original_method_order() ||
+    if (AllowEnhancedClassRedefinition || JvmtiExport::can_maintain_original_method_order() ||
         ((UseSharedSpaces || Arguments::is_dumping_archive()) && length != 0)) {
       guarantee(length == methods()->length(), "invalid method ordering length");
       jlong sum = 0;

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -867,7 +867,7 @@ void JvmtiClassFileReconstituter::write_method_infos() {
   }
 
   write_u2(num_methods - num_overpass);
-  if (JvmtiExport::can_maintain_original_method_order()) {
+  if (AllowEnhancedClassRedefinition || JvmtiExport::can_maintain_original_method_order()) {
     int index;
     int original_index;
     intArray method_order(num_methods, num_methods, 0);

--- a/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.cpp
@@ -368,7 +368,7 @@ void JvmtiManageCapabilities::update() {
   }
 
   JvmtiExport::set_can_get_source_debug_extension(avail.can_get_source_debug_extension);
-  JvmtiExport::set_can_maintain_original_method_order(AllowEnhancedClassRedefinition || avail.can_maintain_original_method_order);
+  JvmtiExport::set_can_maintain_original_method_order(avail.can_maintain_original_method_order);
   JvmtiExport::set_can_post_interpreter_events(interp_events);
   JvmtiExport::set_can_hotswap_or_post_breakpoint(
     avail.can_generate_breakpoint_events ||


### PR DESCRIPTION
We experience a crash when attaching async-profiler to a running JVM in combination with the `AllowEnhancedClassRedefinition` flag. Debugging showed that this is caused by https://github.com/JetBrains/JetBrainsRuntime/blob/41109ce8ba5e7ca202739ea4c03c9c4d7ce2dcff/src/hotspot/share/prims/jvmtiEnv.cpp#L2985 because `JvmtiExport::can_maintain_original_method_order()` is true but the method ordering array wasn't initialized.

We don't quite understand why the flag unconditionally overrides the capability, as the method ordering array is set when the instance class is parsed initially. Retroactively changing the capability does not re-initialize the existing classes, leading to a state mismatch and a JVM crash. Therefore, we propose removing this override.

Alternatively, the `AllowEnhancedClassRedefinition` flag can be added to more places to ensure that the method ordering array is populated during class file parsing. We explored this change in https://github.com/SirYwell/JetBrainsRuntime/commit/62fd69e82d40976a128a3d2cbc8e3a543243178f.

This was initially reported by https://github.com/lucko/spark/issues/426.

I'm not sure how you deal with backports, I'm targetting the jbr21 branch here because that's the version this bug was observed on. Please let me know if you want me to target a different branch.

cc @I-Al-Istannen @intrigus-lgtm