### PR TITLE
JBR-5673: [Wayland] adding horizontal scrolling support

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -1205,7 +1205,7 @@ public class WLComponentPeer implements ComponentPeer {
                         horizontalMWEPreciseRotations = mweConversionInfo.yAxisMWEPreciseRotations;
                         horizontalMWERoundRotations   = mweConversionInfo.yAxisMWERoundRotations;
                     }
-                } else if ((mweConversionInfo.yAxisMWERoundRotations != 0) || (mweConversionInfo.yAxisMWEPreciseRotations != 0)) {
+                } else if (mweConversionInfo.yAxisMWERoundRotations != 0 || mweConversionInfo.yAxisMWEPreciseRotations != 0) {
                     // The scrolling directions contradict.
                     // I think consistently choosing the Y axis values (unless they're zero) provides the most expected UI behavior here.
 
@@ -1236,7 +1236,7 @@ public class WLComponentPeer implements ComponentPeer {
                 yAxisWheelRoundRotationsAccumulator.reset();
             }
 
-            if ((verticalMWERoundRotations != 0) || (verticalMWEPreciseRotations != 0)) {
+            if (verticalMWERoundRotations != 0 || verticalMWEPreciseRotations != 0) {
                 assert(verticalMWEScrollAmount > 0);
 
                 final MouseEvent mouseEvent = new MouseWheelEvent(getTarget(),
@@ -1255,7 +1255,7 @@ public class WLComponentPeer implements ComponentPeer {
                 postMouseEvent(mouseEvent);
             }
 
-            if ((horizontalMWERoundRotations != 0) || (horizontalMWEPreciseRotations != 0)) {
+            if (horizontalMWERoundRotations != 0 || horizontalMWEPreciseRotations != 0) {
                 assert(horizontalMWEScrollAmount > 0);
 
                 final MouseEvent mouseEvent = new MouseWheelEvent(getTarget(),

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -102,6 +102,9 @@ public class WLComponentPeer implements ComponentPeer {
             {"move"}, // MOVE_CURSOR
     };
 
+    // Changing this constant may require adjustments in convertAxisVectorToPreciseWheelRotations
+    private static final int WHEEL_SCROLL_AMOUNT = 3;
+
     private static final int MINIMUM_WIDTH = 1;
     private static final int MINIMUM_HEIGHT = 1;
 
@@ -1086,43 +1089,6 @@ public class WLComponentPeer implements ComponentPeer {
         WLToolkit.postEvent(e);
     }
 
-
-    /**
-     * Accumulates fractional parts of wheel rotations until their absolute sum becomes >=1.
-     * This allows implementing smoother scrolling, e.g., the sequence of wl_pointer::axis events with values
-     *   [0.2, 0.1, 0.4, 0.4] can be accumulated into 1.1=0.2+0.1+0.4+0.4, making it possible to
-     *   generate a MouseWheelEvent with wheelRotation=1
-     *   (instead of 4 tries to generate a MouseWheelEvent with wheelRotation=0 due to double->int conversion)
-     */
-    private static final class MouseWheelRoundRotationsAccumulator {
-        /**
-         * This method is intended to accumulate fractional numbers of wheel rotations.
-         *
-         * @param preciseRotations - fractional number of wheel rotations (usually got from a {@code wl_pointer::axis} event)
-         * @return The number of wheel round rotations accumulated
-         */
-        public int accumulateAndGetRoundRotations(double preciseRotations) {
-            // The code assumes that the target component ({@link WLComponentPeer#target}) never changes.
-            // If it did, {@link #accumulatedPreciseRotations} would have to be reset each time the target changed.
-
-            accumulatedPreciseRotations += preciseRotations;
-            final int result = (int)accumulatedPreciseRotations;
-            accumulatedPreciseRotations -= result;
-
-            return result;
-        }
-
-        private double accumulatedPreciseRotations = 0;
-    }
-
-    private final MouseWheelRoundRotationsAccumulator wheelRoundRotationsAccumulator = new MouseWheelRoundRotationsAccumulator();
-
-    protected double convertAxisVectorToPreciseWheelRotations(double axisVector) {
-        // 0.28 has experimentally been found as providing a good balance between
-        //   wheel scrolling sensitivity and touchpad scrolling sensitivity
-        return axisVector * 0.28;
-    }
-
     /**
      * Creates and posts mouse events based on the given WLPointerEvent received from Wayland,
      * the freshly updated WLInputState, and the previous WLInputState.
@@ -1188,10 +1154,36 @@ public class WLComponentPeer implements ComponentPeer {
             }
         }
 
-        if (e.hasAxisEvent() && e.getIsAxis0Valid()) {
-            final int scrollAmount = 1;
-            final double wheelPreciseRotations = convertAxisVectorToPreciseWheelRotations(e.getAxis0Value());
-            final int wheelRoundRotations = wheelRoundRotationsAccumulator.accumulateAndGetRoundRotations(wheelPreciseRotations);
+        if (e.hasAxisEvent()) {
+            final int scrollAmount;
+            final double wheelPreciseRotations;
+            final int wheelRoundRotations;
+
+            // wl_pointer::axis_discrete/axis_value120 are preferred over wl_pointer::axis because
+            //   they're closer to MouseWheelEvent by their nature.
+            if (e.axis0HasSteps120Value()) {
+                final var steps120Value = e.getAxis0Steps120Value();
+                wheelPreciseRotations = steps120Value / 120.0d;
+                wheelRoundRotations = wheelRoundRotationsAccumulator.accumulateSteps120Rotations(steps120Value);
+                // TODO: It would be probably better to calculate the scrollAmount here taking getAxis0VectorValue() into
+                //       consideration, so that the wheel scrolling speed could be adjusted via some system settings.
+                //       However, neither Gnome nor KDE currently provide such a setting, making it difficult to test
+                //       how well such an approach would work. So leaving it as is for now.
+                scrollAmount = WHEEL_SCROLL_AMOUNT;
+            } else if (e.axis0HasVectorValue()) {
+                final var vectorValue = e.getAxis0VectorValue();
+                wheelPreciseRotations = convertAxisVectorToPreciseWheelRotations(vectorValue);
+                wheelRoundRotations = wheelRoundRotationsAccumulator.accumulateFractionalRotations(wheelPreciseRotations);
+                scrollAmount = 1;
+            } else {
+                wheelRoundRotations = 0;
+                wheelPreciseRotations = 0;
+                scrollAmount = 0;
+            }
+
+            if (e.axis0HasStopEvent()) {
+                wheelRoundRotationsAccumulator.reset();
+            }
 
             if ((wheelRoundRotations != 0) || (wheelPreciseRotations != 0)) {
                 final MouseEvent mouseEvent = new MouseWheelEvent(getTarget(),
@@ -1237,6 +1229,72 @@ public class WLComponentPeer implements ComponentPeer {
             postMouseEvent(mouseEvent);
         }
     }
+
+    /**
+     * Accumulates fractional parts of wheel rotation steps until their absolute sum represents one or more full step(s).
+     * This allows implementing smoother scrolling, e.g., the sequence of wl_pointer::axis events with values
+     *   [0.2, 0.1, 0.4, 0.4] can be accumulated into 1.1=0.2+0.1+0.4+0.4, making it possible to
+     *   generate a MouseWheelEvent with wheelRotation=1
+     *   (instead of 4 tries to generate a MouseWheelEvent with wheelRotation=0 due to double->int conversion)
+     */
+    private static final class MouseWheelRoundRotationsAccumulator {
+        /**
+         * This method is intended to accumulate fractional numbers of wheel rotations.
+         *
+         * @param fractionalRotations - fractional number of wheel rotations (usually got from a {@code wl_pointer::axis} event)
+         * @return The number of wheel round rotations accumulated
+         * @see #accumulateSteps120Rotations
+         */
+        public int accumulateFractionalRotations(double fractionalRotations) {
+            // The code assumes that the target component ({@link WLComponentPeer#target}) never changes.
+            // If it did, all the accumulating fields would have to be reset each time the target changed.
+
+            accumulatedFractionalRotations += fractionalRotations;
+            final int result = (int)accumulatedFractionalRotations;
+            accumulatedFractionalRotations -= result;
+            return result;
+        }
+
+        /**
+         * This method is intended to accumulate 1/120 fractions of a rotation step.
+         *
+         * @param steps120Rotations - a number of 1/120 parts of a wheel step (so that, e.g.,
+         *                            30 means one quarter of a step,
+         *                            240 means two steps,
+         *                            -240 means two steps in the negative direction,
+         *                            540 means 4.5 steps).
+         *                            Usually got from a {@code wl_pointer::axis_discrete}/{@code axis_value120} event.
+         * @return The number of wheel round rotations accumulated
+         * @see #accumulateFractionalRotations
+         */
+        public int accumulateSteps120Rotations(int steps120Rotations) {
+            // The code assumes that the target component ({@link WLComponentPeer#target}) never changes.
+            // If it did, all the accumulating fields would have to be reset each time the target changed.
+
+            accumulatedSteps120Rotations += steps120Rotations;
+            final int result = accumulatedSteps120Rotations / 120;
+            accumulatedSteps120Rotations %= 120;
+            return result;
+        }
+
+        public void reset() {
+            accumulatedFractionalRotations = 0;
+            accumulatedSteps120Rotations = 0;
+        }
+
+
+        private double accumulatedFractionalRotations = 0;
+        private int accumulatedSteps120Rotations = 0;
+    }
+
+    private final MouseWheelRoundRotationsAccumulator wheelRoundRotationsAccumulator = new MouseWheelRoundRotationsAccumulator();
+
+    private double convertAxisVectorToPreciseWheelRotations(double axisVector) {
+        // 0.28 has experimentally been found as providing a good balance between
+        //   wheel scrolling sensitivity and touchpad scrolling sensitivity
+        return axisVector * 0.28;
+    }
+
 
     void startDrag() {
         performLocked(() -> nativeStartDrag(nativePtr));

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -1161,8 +1161,8 @@ public class WLComponentPeer implements ComponentPeer {
 
             // wl_pointer::axis_discrete/axis_value120 are preferred over wl_pointer::axis because
             //   they're closer to MouseWheelEvent by their nature.
-            if (e.axis0HasSteps120Value()) {
-                final var steps120Value = e.getAxis0Steps120Value();
+            if (e.yAxisHasSteps120Value()) {
+                final var steps120Value = e.getYAxisSteps120Value();
                 wheelPreciseRotations = steps120Value / 120.0d;
                 wheelRoundRotations = wheelRoundRotationsAccumulator.accumulateSteps120Rotations(steps120Value);
                 // TODO: It would be probably better to calculate the scrollAmount here taking getAxis0VectorValue() into
@@ -1170,8 +1170,8 @@ public class WLComponentPeer implements ComponentPeer {
                 //       However, neither Gnome nor KDE currently provide such a setting, making it difficult to test
                 //       how well such an approach would work. So leaving it as is for now.
                 scrollAmount = WHEEL_SCROLL_AMOUNT;
-            } else if (e.axis0HasVectorValue()) {
-                final var vectorValue = e.getAxis0VectorValue();
+            } else if (e.yAxisHasVectorValue()) {
+                final var vectorValue = e.getYAxisVectorValue();
                 wheelPreciseRotations = convertAxisVectorToPreciseWheelRotations(vectorValue);
                 wheelRoundRotations = wheelRoundRotationsAccumulator.accumulateFractionalRotations(wheelPreciseRotations);
                 scrollAmount = 1;
@@ -1181,7 +1181,7 @@ public class WLComponentPeer implements ComponentPeer {
                 scrollAmount = 0;
             }
 
-            if (e.axis0HasStopEvent()) {
+            if (e.yAxisHasStopEvent()) {
                 wheelRoundRotationsAccumulator.reset();
             }
 

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLPointerEvent.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLPointerEvent.java
@@ -57,12 +57,19 @@ class WLPointerEvent {
     private int     buttonCode; // pointer button code corresponding to PointerButtonCodes.linuxCode
     private boolean isButtonPressed; // true if button was pressed, false if released
 
-    private boolean axis_0_hasVectorValue;   // whether axis_0_vectorValue is valid
-    private boolean axis_0_hasStopEvent;     // whether wl_pointer::axis_stop event has been received for this axis
-    private boolean axis_0_hasSteps120Value; // whether axis_0_steps120Value is valid
-    private double  axis_0_vectorValue;      // "length of vector in surface-local coordinate space" (source: wayland.xml)
-    private int     axis_0_steps120Value;    // "high-resolution wheel scroll information, with each multiple of 120
-                                             //  representing one logical scroll step (a wheel detent)" (source: wayland.xml)
+    private boolean xAxis_hasVectorValue;   // whether xAxis_vectorValue is valid
+    private boolean xAxis_hasStopEvent;     // whether wl_pointer::axis_stop event has been received for this axis
+    private boolean xAxis_hasSteps120Value; // whether xAxis_steps120Value is valid
+    private double  xAxis_vectorValue;      // "length of vector in surface-local coordinate space" (source: wayland.xml)
+    private int     xAxis_steps120Value;    // "high-resolution wheel scroll information, with each multiple of 120
+                                            //  representing one logical scroll step (a wheel detent)" (source: wayland.xml)
+
+    private boolean yAxis_hasVectorValue;   // whether yAxis_vectorValue is valid
+    private boolean yAxis_hasStopEvent;     // whether wl_pointer::axis_stop event has been received for this axis
+    private boolean yAxis_hasSteps120Value; // whether yAxis_steps120Value is valid
+    private double  yAxis_vectorValue;      // "length of vector in surface-local coordinate space" (source: wayland.xml)
+    private int     yAxis_steps120Value;    // "high-resolution wheel scroll information, with each multiple of 120
+                                            //  representing one logical scroll step (a wheel detent)" (source: wayland.xml)
 
     private WLPointerEvent() {}
 
@@ -178,7 +185,7 @@ class WLPointerEvent {
     }
 
     public boolean hasAxisEvent() {
-        return axis0HasEvents();
+        return xAxisHasEvents() || yAxisHasEvents();
     }
 
     /**
@@ -244,32 +251,60 @@ class WLPointerEvent {
         return isButtonPressed;
     }
 
-    public boolean axis0HasEvents() {
-        return axis0HasVectorValue() ||
-               axis0HasStopEvent()   ||
-               axis0HasSteps120Value();
+    public boolean xAxisHasEvents() {
+        return xAxisHasVectorValue() ||
+               xAxisHasStopEvent()   ||
+               xAxisHasSteps120Value();
     }
 
-    public boolean axis0HasVectorValue() {
-        return axis_0_hasVectorValue;
+    public boolean xAxisHasVectorValue() {
+        return xAxis_hasVectorValue;
     }
 
-    public boolean axis0HasStopEvent() {
-        return axis_0_hasStopEvent;
+    public boolean xAxisHasStopEvent() {
+        return xAxis_hasStopEvent;
     }
 
-    public boolean axis0HasSteps120Value() {
-        return axis_0_hasSteps120Value;
+    public boolean xAxisHasSteps120Value() {
+        return xAxis_hasSteps120Value;
     }
 
-    public double getAxis0VectorValue() {
-        assert axis0HasVectorValue();
-        return axis_0_vectorValue;
+    public double getXAxisVectorValue() {
+        assert xAxisHasVectorValue();
+        return xAxis_vectorValue;
     }
 
-    public int getAxis0Steps120Value() {
-        assert axis0HasSteps120Value();
-        return axis_0_steps120Value;
+    public int getXAxisSteps120Value() {
+        assert xAxisHasSteps120Value();
+        return xAxis_steps120Value;
+    }
+
+    public boolean yAxisHasEvents() {
+        return yAxisHasVectorValue() ||
+               yAxisHasStopEvent()   ||
+               yAxisHasSteps120Value();
+    }
+
+    public boolean yAxisHasVectorValue() {
+        return yAxis_hasVectorValue;
+    }
+
+    public boolean yAxisHasStopEvent() {
+        return yAxis_hasStopEvent;
+    }
+
+    public boolean yAxisHasSteps120Value() {
+        return yAxis_hasSteps120Value;
+    }
+
+    public double getYAxisVectorValue() {
+        assert yAxisHasVectorValue();
+        return yAxis_vectorValue;
+    }
+
+    public int getYAxisSteps120Value() {
+        assert yAxisHasSteps120Value();
+        return yAxis_steps120Value;
     }
 
     @Override
@@ -305,16 +340,29 @@ class WLPointerEvent {
 
         if (hasAxisEvent()) {
             builder.append(" axis");
-            if (axis0HasEvents()) {
+            if (yAxisHasEvents()) {
                 builder.append(" vertical-scroll:");
 
-                if (axis0HasVectorValue()) {
-                    builder.append(" ").append(getAxis0VectorValue());
+                if (yAxisHasVectorValue()) {
+                    builder.append(" ").append(getYAxisVectorValue());
                 }
-                if (axis0HasSteps120Value()) {
-                    builder.append(" ").append(getAxis0Steps120Value()).append("/120 steps");
+                if (yAxisHasSteps120Value()) {
+                    builder.append(" ").append(getYAxisSteps120Value()).append("/120 steps");
                 }
-                if (axis0HasStopEvent()) {
+                if (yAxisHasStopEvent()) {
+                    builder.append(" stop");
+                }
+            }
+            if (xAxisHasEvents()) {
+                builder.append(" horizontal-scroll:");
+
+                if (xAxisHasVectorValue()) {
+                    builder.append(" ").append(getXAxisVectorValue());
+                }
+                if (xAxisHasSteps120Value()) {
+                    builder.append(" ").append(getXAxisSteps120Value()).append("/120 steps");
+                }
+                if (xAxisHasStopEvent()) {
                     builder.append(" stop");
                 }
             }

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLPointerEvent.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLPointerEvent.java
@@ -46,7 +46,6 @@ class WLPointerEvent {
     private boolean has_leave_event;
     private boolean has_motion_event;
     private boolean has_button_event;
-    private boolean has_axis_event;
 
     private long    surface; /// 'struct wl_surface *' this event appertains to
     private long    serial;
@@ -58,8 +57,12 @@ class WLPointerEvent {
     private int     buttonCode; // pointer button code corresponding to PointerButtonCodes.linuxCode
     private boolean isButtonPressed; // true if button was pressed, false if released
 
-    private boolean axis_0_valid; // is vertical scroll included in this event?
-    private double  axis_0_value; // "length of vector in surface-local coordinate space" (source: wayland.xml)
+    private boolean axis_0_hasVectorValue;   // whether axis_0_vectorValue is valid
+    private boolean axis_0_hasStopEvent;     // whether wl_pointer::axis_stop event has been received for this axis
+    private boolean axis_0_hasSteps120Value; // whether axis_0_steps120Value is valid
+    private double  axis_0_vectorValue;      // "length of vector in surface-local coordinate space" (source: wayland.xml)
+    private int     axis_0_steps120Value;    // "high-resolution wheel scroll information, with each multiple of 120
+                                             //  representing one logical scroll step (a wheel detent)" (source: wayland.xml)
 
     private WLPointerEvent() {}
 
@@ -175,7 +178,7 @@ class WLPointerEvent {
     }
 
     public boolean hasAxisEvent() {
-        return has_axis_event;
+        return axis0HasEvents();
     }
 
     /**
@@ -241,14 +244,32 @@ class WLPointerEvent {
         return isButtonPressed;
     }
 
-    public boolean getIsAxis0Valid() {
-        assert hasAxisEvent();
-        return axis_0_valid;
+    public boolean axis0HasEvents() {
+        return axis0HasVectorValue() ||
+               axis0HasStopEvent()   ||
+               axis0HasSteps120Value();
     }
 
-    public double getAxis0Value() {
-        assert hasAxisEvent();
-        return axis_0_value;
+    public boolean axis0HasVectorValue() {
+        return axis_0_hasVectorValue;
+    }
+
+    public boolean axis0HasStopEvent() {
+        return axis_0_hasStopEvent;
+    }
+
+    public boolean axis0HasSteps120Value() {
+        return axis_0_hasSteps120Value;
+    }
+
+    public double getAxis0VectorValue() {
+        assert axis0HasVectorValue();
+        return axis_0_vectorValue;
+    }
+
+    public int getAxis0Steps120Value() {
+        assert axis0HasSteps120Value();
+        return axis_0_steps120Value;
     }
 
     @Override
@@ -283,9 +304,19 @@ class WLPointerEvent {
         }
 
         if (hasAxisEvent()) {
-            builder.append("axis");
-            if (axis_0_valid) {
-                builder.append("vertical-scroll: ").append(axis_0_value).append(" ");
+            builder.append(" axis");
+            if (axis0HasEvents()) {
+                builder.append(" vertical-scroll:");
+
+                if (axis0HasVectorValue()) {
+                    builder.append(" ").append(getAxis0VectorValue());
+                }
+                if (axis0HasSteps120Value()) {
+                    builder.append(" ").append(getAxis0Steps120Value()).append("/120 steps");
+                }
+                if (axis0HasStopEvent()) {
+                    builder.append(" stop");
+                }
             }
         }
 

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLPointerEvent.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLPointerEvent.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2022-2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2024, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ class WLPointerEvent {
     private boolean isButtonPressed; // true if button was pressed, false if released
 
     private boolean axis_0_valid; // is vertical scroll included in this event?
-    private int     axis_0_value; // "length of vector in surface-local coordinate space" (source: wayland.xml)
+    private double  axis_0_value; // "length of vector in surface-local coordinate space" (source: wayland.xml)
 
     private WLPointerEvent() {}
 
@@ -246,7 +246,7 @@ class WLPointerEvent {
         return axis_0_valid;
     }
 
-    public int getAxis0Value() {
+    public double getAxis0Value() {
         assert hasAxisEvent();
         return axis_0_value;
     }

--- a/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
+++ b/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
@@ -102,7 +102,6 @@ static jfieldID hasEnterEventFID;
 static jfieldID hasLeaveEventFID;
 static jfieldID hasMotionEventFID;
 static jfieldID hasButtonEventFID;
-static jfieldID hasAxisEventFID;
 static jfieldID serialFID;
 static jfieldID surfaceFID;
 static jfieldID timestampFID;
@@ -110,8 +109,11 @@ static jfieldID surfaceXFID;
 static jfieldID surfaceYFID;
 static jfieldID buttonCodeFID;
 static jfieldID isButtonPressedFID;
-static jfieldID axis_0_validFID;
-static jfieldID axis_0_valueFID;
+static jfieldID axis_0_hasVectorValueFID;
+static jfieldID axis_0_hasStopEventFID;
+static jfieldID axis_0_hasSteps120ValueFID;
+static jfieldID axis_0_vectorValueFID;
+static jfieldID axis_0_steps120ValueFID;
 
 static jmethodID dispatchKeyboardKeyEventMID;
 static jmethodID dispatchKeyboardModifiersEventMID;
@@ -141,10 +143,7 @@ struct pointer_event_cumulative {
     bool has_leave_event         : 1;
     bool has_motion_event        : 1;
     bool has_button_event        : 1;
-    bool has_axis_event          : 1;
     bool has_axis_source_event   : 1;
-    bool has_axis_stop_event     : 1;
-    bool has_axis_discrete_event : 1;
 
     uint32_t   time;
     uint32_t   serial;
@@ -157,9 +156,19 @@ struct pointer_event_cumulative {
     uint32_t   state;
 
     struct {
-        bool       valid;
-        wl_fixed_t value;
-        int32_t    discrete;
+        // wl_pointer::axis
+        bool has_vector_value   : 1;
+        // wl_pointer::axis_stop
+        bool has_stop_event     : 1;
+        // wl_pointer::axis_discrete or wl_pointer::axis_value120
+        bool has_steps120_value : 1;
+
+        // wl_pointer::axis
+        wl_fixed_t vector_value;
+
+        // wl_pointer::axis_discrete or wl_pointer::axis_value120
+        // In the former case, the value is multiplied by 120 for compatibility with wl_pointer::axis_value120
+        int32_t    steps120_value;
     } axes[2];
     uint32_t axis_source;
 };
@@ -219,10 +228,9 @@ wl_pointer_axis(void *data, struct wl_pointer *wl_pointer, uint32_t time,
 {
     assert(axis < sizeof(pointer_event.axes)/sizeof(pointer_event.axes[0]));
 
-    pointer_event.has_axis_event   = true;
-    pointer_event.time             = time;
-    pointer_event.axes[axis].valid = true;
-    pointer_event.axes[axis].value = value;
+    pointer_event.axes[axis].has_vector_value = true;
+    pointer_event.time                        = time;
+    pointer_event.axes[axis].vector_value     = value;
 }
 
 static void
@@ -239,18 +247,35 @@ wl_pointer_axis_stop(void *data, struct wl_pointer *wl_pointer,
 {
     assert(axis < sizeof(pointer_event.axes)/sizeof(pointer_event.axes[0]));
 
-    pointer_event.has_axis_stop_event = true;
-    pointer_event.time                = time;
-    pointer_event.axes[axis].valid    = true;
+    pointer_event.axes[axis].has_stop_event = true;
+    pointer_event.time                      = time;
 }
 
 static void
 wl_pointer_axis_discrete(void *data, struct wl_pointer *wl_pointer,
                          uint32_t axis, int32_t discrete)
 {
-    pointer_event.has_axis_discrete_event = true;
-    pointer_event.axes[axis].valid        = true;
-    pointer_event.axes[axis].discrete     = discrete;
+    assert(axis < sizeof(pointer_event.axes)/sizeof(pointer_event.axes[0]));
+
+    // wl_pointer::axis_discrete event is deprecated with wl_pointer version 8 - this event is not sent to clients
+    //   supporting version 8 or later.
+    // It's just an additional check to work around possible bugs in compositors when they send both
+    //   wl_pointer::axis_discrete and wl_pointer::axis_value120 events within the same frame.
+    // In this case wl_pointer::axis_value120 would be preferred.
+    if (!pointer_event.axes[axis].has_steps120_value) {
+        pointer_event.axes[axis].has_steps120_value = true;
+        pointer_event.axes[axis].steps120_value     = discrete * 120;
+    }
+}
+
+static void
+wl_pointer_axis_value120(void *data, struct wl_pointer *wl_pointer,
+                         uint32_t axis, int32_t value120)
+{
+    assert(axis < sizeof(pointer_event.axes)/sizeof(pointer_event.axes[0]));
+
+    pointer_event.axes[axis].has_steps120_value = true;
+    pointer_event.axes[axis].steps120_value     = value120;
 }
 
 static inline void
@@ -266,7 +291,6 @@ fillJavaPointerEvent(JNIEnv* env, jobject pointerEventRef)
     (*env)->SetBooleanField(env, pointerEventRef, hasLeaveEventFID, pointer_event.has_leave_event);
     (*env)->SetBooleanField(env, pointerEventRef, hasMotionEventFID, pointer_event.has_motion_event);
     (*env)->SetBooleanField(env, pointerEventRef, hasButtonEventFID, pointer_event.has_button_event);
-    (*env)->SetBooleanField(env, pointerEventRef, hasAxisEventFID, pointer_event.has_axis_event);
 
     (*env)->SetLongField(env, pointerEventRef, surfaceFID, (long)pointer_event.surface);
     (*env)->SetLongField(env, pointerEventRef, serialFID, pointer_event.serial);
@@ -279,8 +303,11 @@ fillJavaPointerEvent(JNIEnv* env, jobject pointerEventRef)
     (*env)->SetBooleanField(env, pointerEventRef, isButtonPressedFID,
                             (pointer_event.state == WL_POINTER_BUTTON_STATE_PRESSED));
 
-    (*env)->SetBooleanField(env, pointerEventRef, axis_0_validFID, pointer_event.axes[0].valid);
-    (*env)->SetDoubleField(env, pointerEventRef, axis_0_valueFID, wl_fixed_to_double(pointer_event.axes[0].value));
+    (*env)->SetBooleanField(env, pointerEventRef, axis_0_hasVectorValueFID, pointer_event.axes[0].has_vector_value);
+    (*env)->SetBooleanField(env, pointerEventRef, axis_0_hasStopEventFID, pointer_event.axes[0].has_stop_event);
+    (*env)->SetBooleanField(env, pointerEventRef, axis_0_hasSteps120ValueFID, pointer_event.axes[0].has_steps120_value);
+    (*env)->SetDoubleField(env, pointerEventRef, axis_0_vectorValueFID, wl_fixed_to_double(pointer_event.axes[0].vector_value));
+    (*env)->SetIntField(env, pointerEventRef, axis_0_steps120ValueFID, pointer_event.axes[0].steps120_value);
 }
 
 static void
@@ -313,7 +340,9 @@ static const struct wl_pointer_listener wl_pointer_listener = {
         .frame         = wl_pointer_frame,
         .axis_source   = wl_pointer_axis_source,
         .axis_stop     = wl_pointer_axis_stop,
-        .axis_discrete = wl_pointer_axis_discrete
+        .axis_discrete = wl_pointer_axis_discrete/*,
+        This is only supported if the libwayland-client supports version 8 of the wl_pointer interface
+        .axis_value120 = wl_pointer_axis_value120*/
 };
 
 
@@ -624,8 +653,6 @@ initJavaRefs(JNIEnv *env, jclass clazz)
                       JNI_FALSE);
     CHECK_NULL_RETURN(hasButtonEventFID = (*env)->GetFieldID(env, pointerEventClass, "has_button_event", "Z"),
                       JNI_FALSE);
-    CHECK_NULL_RETURN(hasAxisEventFID = (*env)->GetFieldID(env, pointerEventClass, "has_axis_event", "Z"),
-                      JNI_FALSE);
 
     CHECK_NULL_RETURN(serialFID = (*env)->GetFieldID(env, pointerEventClass, "serial", "J"), JNI_FALSE);
     CHECK_NULL_RETURN(surfaceFID = (*env)->GetFieldID(env, pointerEventClass, "surface", "J"), JNI_FALSE);
@@ -634,8 +661,17 @@ initJavaRefs(JNIEnv *env, jclass clazz)
     CHECK_NULL_RETURN(surfaceYFID = (*env)->GetFieldID(env, pointerEventClass, "surface_y", "I"), JNI_FALSE);
     CHECK_NULL_RETURN(buttonCodeFID = (*env)->GetFieldID(env, pointerEventClass, "buttonCode", "I"), JNI_FALSE);
     CHECK_NULL_RETURN(isButtonPressedFID = (*env)->GetFieldID(env, pointerEventClass, "isButtonPressed", "Z"), JNI_FALSE);
-    CHECK_NULL_RETURN(axis_0_validFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_valid", "Z"), JNI_FALSE);
-    CHECK_NULL_RETURN(axis_0_valueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_value", "D"), JNI_FALSE);
+
+    CHECK_NULL_RETURN(axis_0_hasVectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_hasVectorValue", "Z"),
+                      JNI_FALSE);
+    CHECK_NULL_RETURN(axis_0_hasStopEventFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_hasStopEvent", "Z"),
+                      JNI_FALSE);
+    CHECK_NULL_RETURN(axis_0_hasSteps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_hasSteps120Value", "Z"),
+                      JNI_FALSE);
+    CHECK_NULL_RETURN(axis_0_vectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_vectorValue", "D"),
+                      JNI_FALSE);
+    CHECK_NULL_RETURN(axis_0_steps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_steps120Value", "I"),
+                      JNI_FALSE);
 
     CHECK_NULL_RETURN(dispatchKeyboardEnterEventMID = (*env)->GetStaticMethodID(env, tkClass,
                                                                                 "dispatchKeyboardEnterEvent",

--- a/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
+++ b/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
@@ -109,11 +109,16 @@ static jfieldID surfaceXFID;
 static jfieldID surfaceYFID;
 static jfieldID buttonCodeFID;
 static jfieldID isButtonPressedFID;
-static jfieldID axis_0_hasVectorValueFID;
-static jfieldID axis_0_hasStopEventFID;
-static jfieldID axis_0_hasSteps120ValueFID;
-static jfieldID axis_0_vectorValueFID;
-static jfieldID axis_0_steps120ValueFID;
+static jfieldID xAxis_hasVectorValueFID;
+static jfieldID xAxis_hasStopEventFID;
+static jfieldID xAxis_hasSteps120ValueFID;
+static jfieldID xAxis_vectorValueFID;
+static jfieldID xAxis_steps120ValueFID;
+static jfieldID yAxis_hasVectorValueFID;
+static jfieldID yAxis_hasStopEventFID;
+static jfieldID yAxis_hasSteps120ValueFID;
+static jfieldID yAxis_vectorValueFID;
+static jfieldID yAxis_steps120ValueFID;
 
 static jmethodID dispatchKeyboardKeyEventMID;
 static jmethodID dispatchKeyboardModifiersEventMID;
@@ -303,11 +308,17 @@ fillJavaPointerEvent(JNIEnv* env, jobject pointerEventRef)
     (*env)->SetBooleanField(env, pointerEventRef, isButtonPressedFID,
                             (pointer_event.state == WL_POINTER_BUTTON_STATE_PRESSED));
 
-    (*env)->SetBooleanField(env, pointerEventRef, axis_0_hasVectorValueFID, pointer_event.axes[0].has_vector_value);
-    (*env)->SetBooleanField(env, pointerEventRef, axis_0_hasStopEventFID, pointer_event.axes[0].has_stop_event);
-    (*env)->SetBooleanField(env, pointerEventRef, axis_0_hasSteps120ValueFID, pointer_event.axes[0].has_steps120_value);
-    (*env)->SetDoubleField(env, pointerEventRef, axis_0_vectorValueFID, wl_fixed_to_double(pointer_event.axes[0].vector_value));
-    (*env)->SetIntField(env, pointerEventRef, axis_0_steps120ValueFID, pointer_event.axes[0].steps120_value);
+    (*env)->SetBooleanField(env, pointerEventRef, xAxis_hasVectorValueFID,   pointer_event.axes[1].has_vector_value);
+    (*env)->SetBooleanField(env, pointerEventRef, xAxis_hasStopEventFID,     pointer_event.axes[1].has_stop_event);
+    (*env)->SetBooleanField(env, pointerEventRef, xAxis_hasSteps120ValueFID, pointer_event.axes[1].has_steps120_value);
+    (*env)->SetDoubleField (env, pointerEventRef, xAxis_vectorValueFID,      wl_fixed_to_double(pointer_event.axes[1].vector_value));
+    (*env)->SetIntField    (env, pointerEventRef, xAxis_steps120ValueFID,    pointer_event.axes[1].steps120_value);
+
+    (*env)->SetBooleanField(env, pointerEventRef, yAxis_hasVectorValueFID,   pointer_event.axes[0].has_vector_value);
+    (*env)->SetBooleanField(env, pointerEventRef, yAxis_hasStopEventFID,     pointer_event.axes[0].has_stop_event);
+    (*env)->SetBooleanField(env, pointerEventRef, yAxis_hasSteps120ValueFID, pointer_event.axes[0].has_steps120_value);
+    (*env)->SetDoubleField (env, pointerEventRef, yAxis_vectorValueFID,      wl_fixed_to_double(pointer_event.axes[0].vector_value));
+    (*env)->SetIntField    (env, pointerEventRef, yAxis_steps120ValueFID,    pointer_event.axes[0].steps120_value);
 }
 
 static void
@@ -662,16 +673,17 @@ initJavaRefs(JNIEnv *env, jclass clazz)
     CHECK_NULL_RETURN(buttonCodeFID = (*env)->GetFieldID(env, pointerEventClass, "buttonCode", "I"), JNI_FALSE);
     CHECK_NULL_RETURN(isButtonPressedFID = (*env)->GetFieldID(env, pointerEventClass, "isButtonPressed", "Z"), JNI_FALSE);
 
-    CHECK_NULL_RETURN(axis_0_hasVectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_hasVectorValue", "Z"),
-                      JNI_FALSE);
-    CHECK_NULL_RETURN(axis_0_hasStopEventFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_hasStopEvent", "Z"),
-                      JNI_FALSE);
-    CHECK_NULL_RETURN(axis_0_hasSteps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_hasSteps120Value", "Z"),
-                      JNI_FALSE);
-    CHECK_NULL_RETURN(axis_0_vectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_vectorValue", "D"),
-                      JNI_FALSE);
-    CHECK_NULL_RETURN(axis_0_steps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_steps120Value", "I"),
-                      JNI_FALSE);
+    CHECK_NULL_RETURN(xAxis_hasVectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "xAxis_hasVectorValue", "Z"), JNI_FALSE);
+    CHECK_NULL_RETURN(xAxis_hasStopEventFID = (*env)->GetFieldID(env, pointerEventClass, "xAxis_hasStopEvent", "Z"), JNI_FALSE);
+    CHECK_NULL_RETURN(xAxis_hasSteps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "xAxis_hasSteps120Value", "Z"), JNI_FALSE);
+    CHECK_NULL_RETURN(xAxis_vectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "xAxis_vectorValue", "D"), JNI_FALSE);
+    CHECK_NULL_RETURN(xAxis_steps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "xAxis_steps120Value", "I"), JNI_FALSE);
+
+    CHECK_NULL_RETURN(yAxis_hasVectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "yAxis_hasVectorValue", "Z"), JNI_FALSE);
+    CHECK_NULL_RETURN(yAxis_hasStopEventFID = (*env)->GetFieldID(env, pointerEventClass, "yAxis_hasStopEvent", "Z"), JNI_FALSE);
+    CHECK_NULL_RETURN(yAxis_hasSteps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "yAxis_hasSteps120Value", "Z"), JNI_FALSE);
+    CHECK_NULL_RETURN(yAxis_vectorValueFID = (*env)->GetFieldID(env, pointerEventClass, "yAxis_vectorValue", "D"), JNI_FALSE);
+    CHECK_NULL_RETURN(yAxis_steps120ValueFID = (*env)->GetFieldID(env, pointerEventClass, "yAxis_steps120Value", "I"), JNI_FALSE);
 
     CHECK_NULL_RETURN(dispatchKeyboardEnterEventMID = (*env)->GetStaticMethodID(env, tkClass,
                                                                                 "dispatchKeyboardEnterEvent",

--- a/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
+++ b/src/java.desktop/unix/native/libawt_wlawt/WLToolkit.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2022-2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2024, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,7 +280,7 @@ fillJavaPointerEvent(JNIEnv* env, jobject pointerEventRef)
                             (pointer_event.state == WL_POINTER_BUTTON_STATE_PRESSED));
 
     (*env)->SetBooleanField(env, pointerEventRef, axis_0_validFID, pointer_event.axes[0].valid);
-    (*env)->SetIntField(env, pointerEventRef, axis_0_valueFID, wl_fixed_to_int(pointer_event.axes[0].value));
+    (*env)->SetDoubleField(env, pointerEventRef, axis_0_valueFID, wl_fixed_to_double(pointer_event.axes[0].value));
 }
 
 static void
@@ -635,7 +635,7 @@ initJavaRefs(JNIEnv *env, jclass clazz)
     CHECK_NULL_RETURN(buttonCodeFID = (*env)->GetFieldID(env, pointerEventClass, "buttonCode", "I"), JNI_FALSE);
     CHECK_NULL_RETURN(isButtonPressedFID = (*env)->GetFieldID(env, pointerEventClass, "isButtonPressed", "Z"), JNI_FALSE);
     CHECK_NULL_RETURN(axis_0_validFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_valid", "Z"), JNI_FALSE);
-    CHECK_NULL_RETURN(axis_0_valueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_value", "I"), JNI_FALSE);
+    CHECK_NULL_RETURN(axis_0_valueFID = (*env)->GetFieldID(env, pointerEventClass, "axis_0_value", "D"), JNI_FALSE);
 
     CHECK_NULL_RETURN(dispatchKeyboardEnterEventMID = (*env)->GetStaticMethodID(env, tkClass,
                                                                                 "dispatchKeyboardEnterEvent",


### PR DESCRIPTION
The patch fixes the inability to scroll along the horizontal axis using a touchpad ([JBR-5673](https://youtrack.jetbrains.com/issue/JBR-5673)) or a secondary mouse wheel, e.g. like on _Logitech MX Master 3_ ([JBR-7296](https://youtrack.jetbrains.com/issue/JBR-7296)).

The patch is heavily based on the changes introduced in #430, so I recommend to familiarize yourself with that one first.

And like for #430, I advise to review the patch commit-by-commit (I think this will help to understand how the changes are related to each other). Each commit solves one particular sub-task, which is described in the commit message. After the review all the commits will be squashed.