### PR TITLE
JBR-7493 Wayland: can't start in maximized state on WSL

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLComponentPeer.java
@@ -522,7 +522,7 @@ public class WLComponentPeer implements ComponentPeer {
         postPaintEvent();
     }
 
-    private boolean isSizeBeingConfigured() {
+    boolean isSizeBeingConfigured() {
         synchronized (dataLock) {
             return sizeIsBeingConfigured;
         }
@@ -1214,12 +1214,6 @@ public class WLComponentPeer implements ComponentPeer {
     void notifyConfigured(int newSurfaceX, int newSurfaceY, int newSurfaceWidth, int newSurfaceHeight, boolean active, boolean maximized) {
         // NB: The width and height, as well as X and Y arguments specify the size and the location
         //     of the window in surface-local coordinates.
-        final long wlSurfacePtr = getWLSurface(nativePtr);
-        if (!surfaceAssigned) {
-            SurfaceData.convertTo(WLSurfaceDataExt.class, surfaceData).assignSurface(wlSurfacePtr);
-            surfaceAssigned = true;
-        }
-
         if (log.isLoggable(PlatformLogger.Level.FINE)) {
             log.fine(String.format("%s configured to %dx%d surface units", this, newSurfaceWidth, newSurfaceHeight));
         }
@@ -1237,6 +1231,12 @@ public class WLComponentPeer implements ComponentPeer {
         boolean clientDecidesDimension = newSurfaceWidth == 0 || newSurfaceHeight == 0;
         if (!clientDecidesDimension) {
             changeSizeToConfigured(newSurfaceWidth, newSurfaceHeight);
+        }
+
+        if (!surfaceAssigned) {
+            long wlSurfacePtr = getWLSurface(nativePtr);
+            SurfaceData.convertTo(WLSurfaceDataExt.class, surfaceData).assignSurface(wlSurfacePtr);
+            surfaceAssigned = true;
         }
 
         if (clientDecidesDimension || isWlPopup) {

--- a/src/java.desktop/unix/classes/sun/awt/wl/WLFramePeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/wl/WLFramePeer.java
@@ -131,6 +131,20 @@ public class WLFramePeer extends WLDecoratedPeer implements FramePeer {
     }
 
     @Override
+    public void setBounds(int newX, int newY, int newWidth, int newHeight, int op) {
+        boolean isMaximized = (getState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH;
+        if (isMaximized && !isSizeBeingConfigured()) {
+            // Some Wayland implementations (Weston) react badly when the size of a maximized
+            // surface differs from the size suggested by Wayland through the "configure" event.
+            // Changing the location of a maximized window does not make sense also, even if it were
+            // possible in Wayland.
+            return;
+        }
+
+        super.setBounds(newX, newY, newWidth, newHeight, op);
+    }
+
+    @Override
     public void setBoundsPrivate(int x, int y, int width, int height) {
         throw new UnsupportedOperationException();
     }

--- a/test/jdk/jb/java/awt/Window/ShowMaximized.java
+++ b/test/jdk/jb/java/awt/Window/ShowMaximized.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.awt.Dimension;
+import java.awt.Robot;
+
+/**
+ * @test
+ * @summary Verifies that a window shown maximized really has the size
+ *          it is supposed to have and ignores prior setSize()
+ * @key headful
+ * @run main ShowMaximized
+ */
+
+public class ShowMaximized {
+    static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("Maximized At Start");
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+                frame.setVisible(true);
+            });
+            pause(robot);
+
+            if (frame.getExtendedState() != JFrame.MAXIMIZED_BOTH) {
+                System.out.println("Can't maximize a window, skipping the test");
+                return;
+            }
+
+            Dimension sizeWhenMaximized = frame.getSize();
+            System.out.println("Size when maximized: " + sizeWhenMaximized);
+
+            SwingUtilities.invokeAndWait(() -> {
+                frame.setExtendedState(JFrame.NORMAL);
+                frame.setVisible(false);
+            });
+            pause(robot);
+
+            SwingUtilities.invokeAndWait(() -> {
+                frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+                frame.setSize(50, 50);
+                frame.setVisible(true);
+            });
+            pause(robot);
+
+            Dimension newSize = frame.getSize();
+            System.out.println("Size when maximized again: " + sizeWhenMaximized);
+            if (!sizeWhenMaximized.equals(newSize)) {
+                throw new RuntimeException("Wrong size when maximized: got " + newSize + ", expected " + sizeWhenMaximized);
+            } else {
+                System.out.println("Test passed");
+            }
+        } finally {
+            frame.dispose();
+        }
+    }
+
+    private static void pause(Robot robot) {
+        robot.waitForIdle();
+        robot.delay(1000);
+    }
+}


### PR DESCRIPTION
[JBR-7493](https://youtrack.jetbrains.com/issue/JBR-7493) Wayland: can't start in maximized state on WSL

Two distinct problems were fixed:
* `assignSurface()` was called too early before the real (coming from the `configure` event) size of the surface had been specified
* it should not be possible to change the size of a maximized surface, except when the change is initiated by Wayland itself (when, for example, the screen scale changes)