### PR TITLE
JBR-7516 Wayland: DamageList_AddList: Assertion `list != add' failed

### DIFF
--- a/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.c
+++ b/src/java.desktop/unix/native/common/java2d/wl/WLBuffers.c
@@ -149,12 +149,13 @@ DamageList_Add(DamageList* list, jint x, jint y, jint width, jint height)
 static DamageList*
 DamageList_AddList(DamageList* list, DamageList* add)
 {
-    assert(list != add);
+    if (add != NULL) {
+        assert(list != add);
 
-    for (DamageList* l = add; l != NULL; l = l->next) {
-        list = DamageList_Add(list, l->x, l->y, l->width, l->height);
+        for (DamageList *l = add; l != NULL; l = l->next) {
+            list = DamageList_Add(list, l->x, l->y, l->width, l->height);
+        }
     }
-
     return list;
 }
 
@@ -928,6 +929,27 @@ DrawBufferResize(WLSurfaceBufferManager * manager)
     }
 }
 
+static void ResetBuffers(WLSurfaceBufferManager * manager) {
+    ASSERT_SHOW_LOCK_IS_HELD(manager);
+
+    // Make sure the draw buffer is not copied from and re-set before drawn upon again
+    MUTEX_LOCK(manager->drawLock);
+    manager->bufferForDraw.resizePending = true;
+    MUTEX_UNLOCK(manager->drawLock);
+
+    // All the damage refers to a surface that doesn't exist anymore; clean the lists
+    // in case these buffers will be re-used for a new surface
+    for (WLSurfaceBuffer* buffer = manager->buffersFree; buffer != NULL; buffer = buffer->next) {
+        DamageList_FreeAll(buffer->damageList);
+        buffer->damageList = NULL;
+    }
+
+    for (WLSurfaceBuffer* buffer = manager->buffersInUse; buffer != NULL; buffer = buffer->next) {
+        DamageList_FreeAll(buffer->damageList);
+        buffer->damageList = NULL;
+    }
+}
+
 static bool
 HaveEnoughMemoryForWindow(jint width, jint height)
 {
@@ -1014,6 +1036,8 @@ WLSBM_SurfaceAssign(WLSurfaceBufferManager * manager, struct wl_surface* wl_surf
             // will not commit anything new for a while, in which case the surface
             // may never get associated with a buffer and the window will never appear.
             TrySendShowBufferToWayland(manager, true);
+        } else {
+            ResetBuffers(manager);
         }
     } else {
         assert(manager->wlSurface == wl_surface);

--- a/test/jdk/jb/java/awt/Window/Reshow.java
+++ b/test/jdk/jb/java/awt/Window/Reshow.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+
+/**
+ * @test
+ * @summary Verifies that nothing prevents repeated calls to Window.setVisible(true)
+ * @key headful
+ * @run main Reshow
+ */
+public class Reshow {
+    public static void main(String[] args) throws Exception {
+        Frame f = new Frame();
+        f.setBounds(200, 200, 290, 140);
+        f.setVisible(true);
+        Thread.sleep(1000);
+        f.setVisible(false);
+        Thread.sleep(1000);
+        f.setVisible(true);
+        Thread.sleep(1000);
+        f.setVisible(false);
+        f.dispose();
+    }
+}


### PR DESCRIPTION
[JBR-7516](https://youtrack.jetbrains.com/issue/JBR-7516) Wayland: DamageList_AddList: Assertion `list != add' failed

The main problem was that both `list` and `add` were `NULL` at the time of the check. This is normal and the check was corrected to account for such a possibility.

However, since buffers can be re-used for a different surface of the same `java.awt.Window` (which will likely have the same size after the second `setVisible(true)`), it's important that those buffers do not retain any residual information from their previous "life".