### PR TITLE
JBR-7568 Vulkan: Refactor VKLogicalDevice into VKDevice

### DIFF
--- a/src/java.desktop/share/native/common/java2d/vulkan/VKBase.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKBase.h
@@ -29,7 +29,7 @@
 #include "VKTypes.h"
 #include "VKTexturePool.h"
 
-struct VKLogicalDevice {
+struct VKDevice {
     VkDevice            device;
     VkPhysicalDevice    physicalDevice;
     VKRenderer*         fillTexturePoly;
@@ -107,10 +107,10 @@ struct VKLogicalDevice {
 
 
 struct VKGraphicsEnvironment {
-    VkInstance              vkInstance;
-    VkPhysicalDevice*       physicalDevices;
-    VKLogicalDevice*        devices;
-    VKLogicalDevice*        currentDevice;
+    VkInstance        vkInstance;
+    VkPhysicalDevice* physicalDevices;
+    VKDevice*         devices;
+    VKDevice*         currentDevice;
 
 #if defined(DEBUG)
     VkDebugUtilsMessengerEXT debugMessenger;

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKBuffer.c
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKBuffer.c
@@ -46,7 +46,7 @@ VkResult VKBuffer_FindMemoryType(VkPhysicalDevice physicalDevice, uint32_t typeF
     return VK_ERROR_UNKNOWN;
 }
 
-VKBuffer* VKBuffer_Create(VKLogicalDevice* logicalDevice, VkDeviceSize size,
+VKBuffer* VKBuffer_Create(VKDevice* device, VkDeviceSize size,
                           VkBufferUsageFlags usage, VkMemoryPropertyFlags properties)
 {
     VKBuffer* buffer = malloc(sizeof (VKBuffer));
@@ -58,7 +58,7 @@ VKBuffer* VKBuffer_Create(VKLogicalDevice* logicalDevice, VkDeviceSize size,
             .sharingMode = VK_SHARING_MODE_EXCLUSIVE
     };
 
-    if (logicalDevice->vkCreateBuffer(logicalDevice->device, &bufferInfo, NULL, &buffer->buffer) != VK_SUCCESS) {
+    if (device->vkCreateBuffer(device->device, &bufferInfo, NULL, &buffer->buffer) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to allocate descriptor sets!")
         return NULL;
     }
@@ -66,11 +66,11 @@ VKBuffer* VKBuffer_Create(VKLogicalDevice* logicalDevice, VkDeviceSize size,
     buffer->size = size;
 
     VkMemoryRequirements memRequirements;
-    logicalDevice->vkGetBufferMemoryRequirements(logicalDevice->device, buffer->buffer, &memRequirements);
+    device->vkGetBufferMemoryRequirements(device->device, buffer->buffer, &memRequirements);
 
     uint32_t memoryType;
 
-    if (VKBuffer_FindMemoryType(logicalDevice->physicalDevice,
+    if (VKBuffer_FindMemoryType(device->physicalDevice,
                                 memRequirements.memoryTypeBits,
                                 properties, &memoryType) != VK_SUCCESS)
     {
@@ -84,27 +84,27 @@ VKBuffer* VKBuffer_Create(VKLogicalDevice* logicalDevice, VkDeviceSize size,
             .memoryTypeIndex = memoryType
     };
 
-    if (logicalDevice->vkAllocateMemory(logicalDevice->device, &allocInfo, NULL, &buffer->memory) != VK_SUCCESS) {
+    if (device->vkAllocateMemory(device->device, &allocInfo, NULL, &buffer->memory) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to allocate buffer memory!");
         return NULL;
     }
 
-    if (logicalDevice->vkBindBufferMemory(logicalDevice->device, buffer->buffer, buffer->memory, 0) != VK_SUCCESS) {
+    if (device->vkBindBufferMemory(device->device, buffer->buffer, buffer->memory, 0) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to bind buffer memory!");
         return NULL;
     }
     return buffer;
 }
 
-VKBuffer* VKBuffer_CreateFromData(VKLogicalDevice* logicalDevice, void* vertices, VkDeviceSize bufferSize)
+VKBuffer* VKBuffer_CreateFromData(VKDevice* device, void* vertices, VkDeviceSize bufferSize)
 {
-    VKBuffer* buffer = VKBuffer_Create(logicalDevice, bufferSize,
+    VKBuffer* buffer = VKBuffer_Create(device, bufferSize,
                                        VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
                                        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
                                        VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
     void* data;
-    if (logicalDevice->vkMapMemory(logicalDevice->device, buffer->memory, 0, bufferSize, 0, &data) != VK_SUCCESS) {
+    if (device->vkMapMemory(device->device, buffer->memory, 0, bufferSize, 0, &data) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to map memory!");
         return NULL;
     }
@@ -119,23 +119,23 @@ VKBuffer* VKBuffer_CreateFromData(VKLogicalDevice* logicalDevice, void* vertices
     };
 
 
-    if (logicalDevice->vkFlushMappedMemoryRanges(logicalDevice->device, 1, &memoryRange) != VK_SUCCESS) {
+    if (device->vkFlushMappedMemoryRanges(device->device, 1, &memoryRange) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to flush memory!");
         return NULL;
     }
-    logicalDevice->vkUnmapMemory(logicalDevice->device, buffer->memory);
+    device->vkUnmapMemory(device->device, buffer->memory);
     buffer->size = bufferSize;
 
     return buffer;
 }
 
-void VKBuffer_free(VKLogicalDevice* logicalDevice, VKBuffer* buffer) {
+void VKBuffer_free(VKDevice* device, VKBuffer* buffer) {
     if (buffer != NULL) {
         if (buffer->buffer != VK_NULL_HANDLE) {
-            logicalDevice->vkDestroyBuffer(logicalDevice->device, buffer->buffer, NULL);
+            device->vkDestroyBuffer(device->device, buffer->buffer, NULL);
         }
         if (buffer->memory != VK_NULL_HANDLE) {
-            logicalDevice->vkFreeMemory(logicalDevice->device, buffer->memory, NULL);
+            device->vkFreeMemory(device->device, buffer->memory, NULL);
         }
         free(buffer);
     }

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKBuffer.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKBuffer.h
@@ -38,11 +38,11 @@ struct VKBuffer {
 VkResult VKBuffer_FindMemoryType(VkPhysicalDevice physicalDevice, uint32_t typeFilter,
                                  VkMemoryPropertyFlags properties, uint32_t* pMemoryType);
 
-VKBuffer* VKBuffer_Create(VKLogicalDevice* logicalDevice, VkDeviceSize size,
+VKBuffer* VKBuffer_Create(VKDevice* device, VkDeviceSize size,
                           VkBufferUsageFlags usage, VkMemoryPropertyFlags properties);
 
-VKBuffer* VKBuffer_CreateFromData(VKLogicalDevice* logicalDevice, void* vertices, VkDeviceSize bufferSize);
+VKBuffer* VKBuffer_CreateFromData(VKDevice* device, void* vertices, VkDeviceSize bufferSize);
 
-void VKBuffer_free(VKLogicalDevice* logicalDevice, VKBuffer* buffer);
+void VKBuffer_free(VKDevice* device, VKBuffer* buffer);
 
 #endif // VKBuffer_h_Included

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKImage.c
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKImage.c
@@ -31,7 +31,7 @@
 #include "VKImage.h"
 
 
-VkBool32 VKImage_CreateView(VKLogicalDevice* logicalDevice, VKImage* image) {
+VkBool32 VKImage_CreateView(VKDevice* device, VKImage* image) {
     VkImageViewCreateInfo viewInfo = {
             .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
             .image = image->image,
@@ -44,14 +44,14 @@ VkBool32 VKImage_CreateView(VKLogicalDevice* logicalDevice, VKImage* image) {
             .subresourceRange.layerCount = 1,
     };
 
-    if (logicalDevice->vkCreateImageView(logicalDevice->device, &viewInfo, NULL, &image->view) != VK_SUCCESS) {
+    if (device->vkCreateImageView(device->device, &viewInfo, NULL, &image->view) != VK_SUCCESS) {
         J2dRlsTrace(J2D_TRACE_ERROR, "Cannot surface image view\n");
         return VK_FALSE;
     }
     return VK_TRUE;
 }
 
-VkBool32 VKImage_CreateFramebuffer(VKLogicalDevice* logicalDevice, VKImage *image, VkRenderPass renderPass) {
+VkBool32 VKImage_CreateFramebuffer(VKDevice* device, VKImage *image, VkRenderPass renderPass) {
     VkImageView attachments[] = {
             image->view
     };
@@ -66,7 +66,7 @@ VkBool32 VKImage_CreateFramebuffer(VKLogicalDevice* logicalDevice, VKImage *imag
             .layers = 1
     };
 
-    if (logicalDevice->vkCreateFramebuffer(logicalDevice->device, &framebufferInfo, NULL,
+    if (device->vkCreateFramebuffer(device->device, &framebufferInfo, NULL,
                                 &image->framebuffer) != VK_SUCCESS)
     {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to create framebuffer!")
@@ -75,7 +75,7 @@ VkBool32 VKImage_CreateFramebuffer(VKLogicalDevice* logicalDevice, VKImage *imag
     return VK_TRUE;
 }
 
-VKImage* VKImage_Create(VKLogicalDevice* logicalDevice,
+VKImage* VKImage_Create(VKDevice* device,
                         uint32_t width, uint32_t height,
                         VkFormat format, VkImageTiling tiling,
                         VkImageUsageFlags usage,
@@ -109,22 +109,22 @@ VKImage* VKImage_Create(VKLogicalDevice* logicalDevice,
             .sharingMode = VK_SHARING_MODE_EXCLUSIVE
     };
 
-    if (logicalDevice->vkCreateImage(logicalDevice->device, &imageInfo, NULL, &image->image) != VK_SUCCESS) {
+    if (device->vkCreateImage(device->device, &imageInfo, NULL, &image->image) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "Cannot create surface image")
-        VKImage_free(logicalDevice, image);
+        VKImage_free(device, image);
         return NULL;
     }
 
     VkMemoryRequirements memRequirements;
-    logicalDevice->vkGetImageMemoryRequirements(logicalDevice->device, image->image, &memRequirements);
+    device->vkGetImageMemoryRequirements(device->device, image->image, &memRequirements);
 
     uint32_t memoryType;
-    if (VKBuffer_FindMemoryType(logicalDevice->physicalDevice,
+    if (VKBuffer_FindMemoryType(device->physicalDevice,
                                 memRequirements.memoryTypeBits,
                                 properties, &memoryType) != VK_SUCCESS)
     {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "Failed to find memory")
-        VKImage_free(logicalDevice, image);
+        VKImage_free(device, image);
         return NULL;
     }
 
@@ -134,28 +134,28 @@ VKImage* VKImage_Create(VKLogicalDevice* logicalDevice,
             .memoryTypeIndex = memoryType
     };
 
-    if (logicalDevice->vkAllocateMemory(logicalDevice->device, &allocInfo, NULL, &image->memory) != VK_SUCCESS) {
+    if (device->vkAllocateMemory(device->device, &allocInfo, NULL, &image->memory) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "Failed to allocate image memory");
-        VKImage_free(logicalDevice, image);
+        VKImage_free(device, image);
         return NULL;
     }
 
-    logicalDevice->vkBindImageMemory(logicalDevice->device, image->image, image->memory, 0);
+    device->vkBindImageMemory(device->device, image->image, image->memory, 0);
 
-    if (!VKImage_CreateView(logicalDevice, image)) {
-        VKImage_free(logicalDevice, image);
+    if (!VKImage_CreateView(device, image)) {
+        VKImage_free(device, image);
         return NULL;
     }
 
     return image;
 }
 
-VKImage* VKImage_CreateImageArrayFromSwapChain(VKLogicalDevice* logicalDevice,
+VKImage* VKImage_CreateImageArrayFromSwapChain(VKDevice* device,
                                                VkSwapchainKHR swapchainKhr, VkRenderPass renderPass,
                                                VkFormat format, VkExtent2D extent)
 {
     uint32_t swapChainImagesCount;
-    if (logicalDevice->vkGetSwapchainImagesKHR(logicalDevice->device, swapchainKhr, &swapChainImagesCount,
+    if (device->vkGetSwapchainImagesKHR(device->device, swapchainKhr, &swapChainImagesCount,
                                     NULL) != VK_SUCCESS) {
         J2dRlsTrace(J2D_TRACE_ERROR, "Cannot get swapchain images\n");
         return NULL;
@@ -167,7 +167,7 @@ VKImage* VKImage_CreateImageArrayFromSwapChain(VKLogicalDevice* logicalDevice,
     }
     VkImage swapChainImages[swapChainImagesCount];
 
-    if (logicalDevice->vkGetSwapchainImagesKHR(logicalDevice->device, swapchainKhr, &swapChainImagesCount,
+    if (device->vkGetSwapchainImagesKHR(device->device, swapchainKhr, &swapChainImagesCount,
                                     swapChainImages) != VK_SUCCESS) {
         J2dRlsTrace(J2D_TRACE_ERROR, "Cannot get swapchain images\n");
         return NULL;
@@ -183,14 +183,14 @@ VKImage* VKImage_CreateImageArrayFromSwapChain(VKLogicalDevice* logicalDevice,
                 .noImageDealloc = VK_TRUE
         }));
 
-        if (!VKImage_CreateView(logicalDevice, &ARRAY_LAST(images))) {
-            ARRAY_APPLY_TRAILING(images, VKImage_dealloc, logicalDevice);
+        if (!VKImage_CreateView(device, &ARRAY_LAST(images))) {
+            ARRAY_APPLY_TRAILING(images, VKImage_dealloc, device);
             ARRAY_FREE(images);
             return NULL;
         }
 
-        if (!VKImage_CreateFramebuffer(logicalDevice, &ARRAY_LAST(images), renderPass)) {
-            ARRAY_APPLY_TRAILING(images, VKImage_dealloc, logicalDevice);
+        if (!VKImage_CreateFramebuffer(device, &ARRAY_LAST(images), renderPass)) {
+            ARRAY_APPLY_TRAILING(images, VKImage_dealloc, device);
             ARRAY_FREE(images);
             return NULL;
         }
@@ -199,31 +199,31 @@ VKImage* VKImage_CreateImageArrayFromSwapChain(VKLogicalDevice* logicalDevice,
     return images;
 }
 
-void VKImage_dealloc(VKLogicalDevice* logicalDevice, VKImage* image) {
+void VKImage_dealloc(VKDevice* device, VKImage* image) {
     if (!image) return;
 
     if (image->framebuffer != VK_NULL_HANDLE) {
-        logicalDevice->vkDestroyFramebuffer(logicalDevice->device, image->framebuffer, NULL);
+        device->vkDestroyFramebuffer(device->device, image->framebuffer, NULL);
         image->framebuffer = VK_NULL_HANDLE;
     }
 
     if (image->view != VK_NULL_HANDLE) {
-        logicalDevice->vkDestroyImageView(logicalDevice->device, image->view, NULL);
+        device->vkDestroyImageView(device->device, image->view, NULL);
         image->view = VK_NULL_HANDLE;
     }
 
     if (image->memory != VK_NULL_HANDLE) {
-        logicalDevice->vkFreeMemory(logicalDevice->device, image->memory, NULL);
+        device->vkFreeMemory(device->device, image->memory, NULL);
         image->memory = VK_NULL_HANDLE;
     }
 
     if (image->image != VK_NULL_HANDLE && !image->noImageDealloc) {
-        logicalDevice->vkDestroyImage(logicalDevice->device, image->image, NULL);
+        device->vkDestroyImage(device->device, image->image, NULL);
         image->image = VK_NULL_HANDLE;
     }
 }
 
-void VKImage_free(VKLogicalDevice* logicalDevice, VKImage* image) {
-    VKImage_dealloc(logicalDevice, image);
+void VKImage_free(VKDevice* device, VKImage* image) {
+    VKImage_dealloc(device, image);
     free(image);
 }

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKImage.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKImage.h
@@ -39,21 +39,21 @@ struct VKImage {
     VkBool32                noImageDealloc;
 };
 
-VKImage* VKImage_Create(VKLogicalDevice* logicalDevice,
+VKImage* VKImage_Create(VKDevice* device,
                         uint32_t width, uint32_t height,
                         VkFormat format, VkImageTiling tiling,
                         VkImageUsageFlags usage,
                         VkMemoryPropertyFlags properties);
 
-VKImage* VKImage_CreateImageArrayFromSwapChain(VKLogicalDevice* logicalDevice,
+VKImage* VKImage_CreateImageArrayFromSwapChain(VKDevice* device,
                                                VkSwapchainKHR swapchainKhr,
                                                VkRenderPass renderPass,
                                                VkFormat format,
                                                VkExtent2D extent);
 
-VkBool32 VKImage_CreateFramebuffer(VKLogicalDevice* logicalDevice,
+VkBool32 VKImage_CreateFramebuffer(VKDevice* device,
                                    VKImage *image, VkRenderPass renderPass);
 
-void VKImage_free(VKLogicalDevice* logicalDevice, VKImage* image);
-void VKImage_dealloc(VKLogicalDevice* logicalDevice, VKImage* image);
+void VKImage_free(VKDevice* device, VKImage* image);
+void VKImage_dealloc(VKDevice* device, VKImage* image);
 #endif // VKImage_h_Included

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKRenderQueue.c
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKRenderQueue.c
@@ -65,7 +65,7 @@
 
 static VKSDOps *dstOps = NULL;
 
-static VKLogicalDevice* currentDevice;
+static VKDevice* currentDevice;
 
 // TODO move this property to special drawing context structure
 static int color = -1;

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKRenderer.c
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKRenderer.c
@@ -40,27 +40,27 @@
 #undef SHADER_ENTRY
 #undef BYTECODE_END
 
-VkShaderModule createShaderModule(VKLogicalDevice* logicalDevice, uint32_t* shader, uint32_t sz) {
+VkShaderModule createShaderModule(VKDevice* device, uint32_t* shader, uint32_t sz) {
     VkShaderModuleCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     createInfo.codeSize = sz;
     createInfo.pCode = (uint32_t*)shader;
     VkShaderModule shaderModule;
-    if (logicalDevice->vkCreateShaderModule(logicalDevice->device, &createInfo, NULL, &shaderModule) != VK_SUCCESS) {
+    if (device->vkCreateShaderModule(device->device, &createInfo, NULL, &shaderModule) != VK_SUCCESS) {
         J2dRlsTrace(J2D_TRACE_ERROR, "failed to create shader module\n")
         return VK_NULL_HANDLE;
     }
     return shaderModule;
 }
 
-VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
+VKRenderer* VKRenderer_CreateFillTexturePoly(VKDevice* device) {
     VKRenderer* fillTexturePoly = malloc(sizeof (VKRenderer ));
 
-    VkDevice device = logicalDevice->device;
+    VkDevice device = device->device;
 
     // Create graphics pipeline
-    VkShaderModule vertShaderModule = createShaderModule(logicalDevice, blit_vert_data, sizeof (blit_vert_data));
-    VkShaderModule fragShaderModule = createShaderModule(logicalDevice, blit_frag_data, sizeof (blit_frag_data));
+    VkShaderModule vertShaderModule = createShaderModule(device, blit_vert_data, sizeof (blit_vert_data));
+    VkShaderModule fragShaderModule = createShaderModule(device, blit_frag_data, sizeof (blit_frag_data));
 
     VkPipelineShaderStageCreateInfo vertShaderStageInfo = {
             .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
@@ -162,7 +162,7 @@ VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
             .pBindings = &samplerLayoutBinding
     };
 
-    if (logicalDevice->vkCreateDescriptorSetLayout(device, &layoutInfo, NULL, &fillTexturePoly->descriptorSetLayout) != VK_SUCCESS) {
+    if (device->vkCreateDescriptorSetLayout(device, &layoutInfo, NULL, &fillTexturePoly->descriptorSetLayout) != VK_SUCCESS) {
         J2dRlsTrace(J2D_TRACE_INFO,  "failed to create descriptor set layout!");
         return JNI_FALSE;
     }
@@ -174,7 +174,7 @@ VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
             .pushConstantRangeCount = 0
     };
 
-    if (logicalDevice->vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL,
+    if (device->vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL,
                                    &fillTexturePoly->pipelineLayout) != VK_SUCCESS)
     {
         J2dRlsTrace(J2D_TRACE_INFO, "failed to create pipeline layout!\n")
@@ -193,20 +193,20 @@ VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
             .pColorBlendState = &colorBlending,
             .pDynamicState = &dynamicState,
             .layout = fillTexturePoly->pipelineLayout,
-            .renderPass = logicalDevice->renderPass,
+            .renderPass = device->renderPass,
             .subpass = 0,
             .basePipelineHandle = VK_NULL_HANDLE,
             .basePipelineIndex = -1
     };
 
-    if (logicalDevice->vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL,
+    if (device->vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL,
                                               &fillTexturePoly->graphicsPipeline) != VK_SUCCESS)
     {
         J2dRlsTrace(J2D_TRACE_INFO, "failed to create graphics pipeline!\n")
         return JNI_FALSE;
     }
-    logicalDevice->vkDestroyShaderModule(device, fragShaderModule, NULL);
-    logicalDevice->vkDestroyShaderModule(device, vertShaderModule, NULL);
+    device->vkDestroyShaderModule(device, fragShaderModule, NULL);
+    device->vkDestroyShaderModule(device, vertShaderModule, NULL);
 
     VkSamplerCreateInfo samplerInfo = {
             .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
@@ -228,7 +228,7 @@ VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
             .maxLod = 0.0f
     };
 
-    if (logicalDevice->vkCreateSampler(device, &samplerInfo, NULL, &logicalDevice->textureSampler) != VK_SUCCESS) {
+    if (device->vkCreateSampler(device, &samplerInfo, NULL, &device->textureSampler) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_INFO, "failed to create texture sampler!");
         return JNI_FALSE;
     }
@@ -245,7 +245,7 @@ VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
             .maxSets = 1
     };
 
-    if (logicalDevice->vkCreateDescriptorPool(device, &descrPoolInfo, NULL, &fillTexturePoly->descriptorPool) != VK_SUCCESS) {
+    if (device->vkCreateDescriptorPool(device, &descrPoolInfo, NULL, &fillTexturePoly->descriptorPool) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_INFO, "failed to create descriptor pool!")
         return JNI_FALSE;
     }
@@ -257,7 +257,7 @@ VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
             .pSetLayouts = &fillTexturePoly->descriptorSetLayout
     };
 
-    if (logicalDevice->vkAllocateDescriptorSets(device, &descrAllocInfo, &fillTexturePoly->descriptorSets) != VK_SUCCESS) {
+    if (device->vkAllocateDescriptorSets(device, &descrAllocInfo, &fillTexturePoly->descriptorSets) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to allocate descriptor sets!");
         return JNI_FALSE;
     }
@@ -265,17 +265,17 @@ VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice) {
     return fillTexturePoly;
 }
 
-VKRenderer *VKRenderer_CreateRenderColorPoly(VKLogicalDevice* logicalDevice,
+VKRenderer *VKRenderer_CreateRenderColorPoly(VKDevice* device,
                                              VkPrimitiveTopology primitiveTopology,
                                              VkPolygonMode polygonMode)
 {
     VKRenderer* renderColorPoly = malloc(sizeof (VKRenderer ));
 
-    VkDevice device = logicalDevice->device;
+    VkDevice device = device->device;
 
     // Create graphics pipeline
-    VkShaderModule vertShaderModule = createShaderModule(logicalDevice, color_vert_data, sizeof (color_vert_data));
-    VkShaderModule fragShaderModule = createShaderModule(logicalDevice, color_frag_data, sizeof (color_frag_data));
+    VkShaderModule vertShaderModule = createShaderModule(device, color_vert_data, sizeof (color_vert_data));
+    VkShaderModule fragShaderModule = createShaderModule(device, color_frag_data, sizeof (color_frag_data));
 
     VkPipelineShaderStageCreateInfo vertShaderStageInfo = {
             .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
@@ -376,7 +376,7 @@ VKRenderer *VKRenderer_CreateRenderColorPoly(VKLogicalDevice* logicalDevice,
             .pPushConstantRanges = &pushConstantRange
     };
 
-    if (logicalDevice->vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL,
+    if (device->vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL,
                                    &renderColorPoly->pipelineLayout) != VK_SUCCESS)
     {
         J2dRlsTrace(J2D_TRACE_INFO, "failed to create pipeline layout!\n")
@@ -395,32 +395,32 @@ VKRenderer *VKRenderer_CreateRenderColorPoly(VKLogicalDevice* logicalDevice,
             .pColorBlendState = &colorBlending,
             .pDynamicState = &dynamicState,
             .layout = renderColorPoly->pipelineLayout,
-            .renderPass = logicalDevice->renderPass,
+            .renderPass = device->renderPass,
             .subpass = 0,
             .basePipelineHandle = VK_NULL_HANDLE,
             .basePipelineIndex = -1
     };
 
-    if (logicalDevice->vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL,
+    if (device->vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL,
                                       &renderColorPoly->graphicsPipeline) != VK_SUCCESS)
     {
         J2dRlsTrace(J2D_TRACE_INFO, "failed to create graphics pipeline!\n")
         return JNI_FALSE;
     }
-    logicalDevice->vkDestroyShaderModule(device, fragShaderModule, NULL);
-    logicalDevice->vkDestroyShaderModule(device, vertShaderModule, NULL);
+    device->vkDestroyShaderModule(device, fragShaderModule, NULL);
+    device->vkDestroyShaderModule(device, vertShaderModule, NULL);
     renderColorPoly->primitiveTopology = primitiveTopology;
     return renderColorPoly;
 }
 
-VKRenderer* VKRenderer_CreateFillMaxColorPoly(VKLogicalDevice* logicalDevice) {
+VKRenderer* VKRenderer_CreateFillMaxColorPoly(VKDevice* device) {
     VKRenderer* fillColorPoly = malloc(sizeof (VKRenderer ));
 
-    VkDevice device = logicalDevice->device;
+    VkDevice device = device->device;
 
     // Create graphics pipeline
-    VkShaderModule vertShaderModule = createShaderModule(logicalDevice, color_max_rect_vert_data, sizeof (color_max_rect_vert_data));
-    VkShaderModule fragShaderModule = createShaderModule(logicalDevice, color_max_rect_frag_data, sizeof (color_max_rect_frag_data));
+    VkShaderModule vertShaderModule = createShaderModule(device, color_max_rect_vert_data, sizeof (color_max_rect_vert_data));
+    VkShaderModule fragShaderModule = createShaderModule(device, color_max_rect_frag_data, sizeof (color_max_rect_frag_data));
 
     VkPipelineShaderStageCreateInfo vertShaderStageInfo = {
             .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
@@ -518,7 +518,7 @@ VKRenderer* VKRenderer_CreateFillMaxColorPoly(VKLogicalDevice* logicalDevice) {
             .pPushConstantRanges = &pushConstantRange
     };
 
-    if (logicalDevice->vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL,
+    if (device->vkCreatePipelineLayout(device, &pipelineLayoutInfo, NULL,
                                    &fillColorPoly->pipelineLayout) != VK_SUCCESS)
     {
         J2dRlsTrace(J2D_TRACE_INFO, "failed to create pipeline layout!\n")
@@ -537,43 +537,43 @@ VKRenderer* VKRenderer_CreateFillMaxColorPoly(VKLogicalDevice* logicalDevice) {
             .pColorBlendState = &colorBlending,
             .pDynamicState = &dynamicState,
             .layout = fillColorPoly->pipelineLayout,
-            .renderPass = logicalDevice->renderPass,
+            .renderPass = device->renderPass,
             .subpass = 0,
             .basePipelineHandle = VK_NULL_HANDLE,
             .basePipelineIndex = -1
     };
 
-    if (logicalDevice->vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL,
+    if (device->vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipelineInfo, NULL,
                                       &fillColorPoly->graphicsPipeline) != VK_SUCCESS)
     {
         J2dRlsTrace(J2D_TRACE_INFO, "failed to create graphics pipeline!\n")
         return JNI_FALSE;
     }
-    logicalDevice->vkDestroyShaderModule(device, fragShaderModule, NULL);
-    logicalDevice->vkDestroyShaderModule(device, vertShaderModule, NULL);
+    device->vkDestroyShaderModule(device, fragShaderModule, NULL);
+    device->vkDestroyShaderModule(device, vertShaderModule, NULL);
     fillColorPoly->primitiveTopology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
     return fillColorPoly;
 }
 
-void VKRenderer_BeginRendering(VKLogicalDevice* logicalDevice) {
+void VKRenderer_BeginRendering(VKDevice* device) {
     VkCommandBufferBeginInfo beginInfo = {};
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
 
-    if (logicalDevice->vkBeginCommandBuffer(logicalDevice->commandBuffer, &beginInfo) != VK_SUCCESS) {
+    if (device->vkBeginCommandBuffer(device->commandBuffer, &beginInfo) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to begin recording command buffer!");
         return;
     }
 }
 
-void VKRenderer_EndRendering(VKLogicalDevice* logicalDevice, VkBool32 notifyRenderFinish, VkBool32 waitForDisplayImage) {
-    if (logicalDevice->vkEndCommandBuffer(logicalDevice->commandBuffer) != VK_SUCCESS) {
+void VKRenderer_EndRendering(VKDevice* device, VkBool32 notifyRenderFinish, VkBool32 waitForDisplayImage) {
+    if (device->vkEndCommandBuffer(device->commandBuffer) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "failed to record command buffer!")
         return;
     }
 
-    VkSemaphore waitSemaphores[] = {logicalDevice->imageAvailableSemaphore};
+    VkSemaphore waitSemaphores[] = {device->imageAvailableSemaphore};
     VkPipelineStageFlags waitStages[] = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT};
-    VkSemaphore signalSemaphores[] = {logicalDevice->renderFinishedSemaphore};
+    VkSemaphore signalSemaphores[] = {device->renderFinishedSemaphore};
 
     VkSubmitInfo submitInfo = {
             .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
@@ -581,29 +581,29 @@ void VKRenderer_EndRendering(VKLogicalDevice* logicalDevice, VkBool32 notifyRend
             .pWaitSemaphores = waitSemaphores,
             .pWaitDstStageMask = waitStages,
             .commandBufferCount = 1,
-            .pCommandBuffers = &logicalDevice->commandBuffer,
+            .pCommandBuffers = &device->commandBuffer,
             .signalSemaphoreCount = (notifyRenderFinish ? 1 : 0),
             .pSignalSemaphores = signalSemaphores
     };
 
-    if (logicalDevice->vkQueueSubmit(logicalDevice->queue, 1, &submitInfo, logicalDevice->inFlightFence) != VK_SUCCESS) {
+    if (device->vkQueueSubmit(device->queue, 1, &submitInfo, device->inFlightFence) != VK_SUCCESS) {
         J2dRlsTraceLn(J2D_TRACE_ERROR,"failed to submit draw command buffer!")
         return;
     }
 }
 
-void VKRenderer_TextureRender(VKLogicalDevice* logicalDevice, VKImage *destImage, VKImage *srcImage,
+void VKRenderer_TextureRender(VKDevice* device, VKImage *destImage, VKImage *srcImage,
                               VkBuffer vertexBuffer, uint32_t vertexNum)
 {
     VkDescriptorImageInfo imageInfo = {
             .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
             .imageView = srcImage->view,
-            .sampler = logicalDevice->textureSampler
+            .sampler = device->textureSampler
     };
 
     VkWriteDescriptorSet descriptorWrites = {
             .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-            .dstSet = logicalDevice->fillTexturePoly->descriptorSets,
+            .dstSet = device->fillTexturePoly->descriptorSets,
             .dstBinding = 0,
             .dstArrayElement = 0,
             .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
@@ -611,13 +611,13 @@ void VKRenderer_TextureRender(VKLogicalDevice* logicalDevice, VKImage *destImage
             .pImageInfo = &imageInfo
     };
 
-    logicalDevice->vkUpdateDescriptorSets(logicalDevice->device, 1, &descriptorWrites, 0, NULL);
+    device->vkUpdateDescriptorSets(device->device, 1, &descriptorWrites, 0, NULL);
 
 
     VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
     VkRenderPassBeginInfo renderPassInfo = {
             .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-            .renderPass = logicalDevice->renderPass,
+            .renderPass = device->renderPass,
             .framebuffer = destImage->framebuffer,
             .renderArea.offset = (VkOffset2D){0, 0},
             .renderArea.extent = destImage->extent,
@@ -625,13 +625,13 @@ void VKRenderer_TextureRender(VKLogicalDevice* logicalDevice, VKImage *destImage
             .pClearValues = &clearColor
     };
 
-    logicalDevice->vkCmdBeginRenderPass(logicalDevice->commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
-    logicalDevice->vkCmdBindPipeline(logicalDevice->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                          logicalDevice->fillTexturePoly->graphicsPipeline);
+    device->vkCmdBeginRenderPass(device->commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+    device->vkCmdBindPipeline(device->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                          device->fillTexturePoly->graphicsPipeline);
 
     VkBuffer vertexBuffers[] = {vertexBuffer};
     VkDeviceSize offsets[] = {0};
-    logicalDevice->vkCmdBindVertexBuffers(logicalDevice->commandBuffer, 0, 1, vertexBuffers, offsets);
+    device->vkCmdBindVertexBuffers(device->commandBuffer, 0, 1, vertexBuffers, offsets);
     VkViewport viewport = {
             .x = 0.0f,
             .y = 0.0f,
@@ -641,24 +641,24 @@ void VKRenderer_TextureRender(VKLogicalDevice* logicalDevice, VKImage *destImage
             .maxDepth = 1.0f
     };
 
-    logicalDevice->vkCmdSetViewport(logicalDevice->commandBuffer, 0, 1, &viewport);
+    device->vkCmdSetViewport(device->commandBuffer, 0, 1, &viewport);
 
     VkRect2D scissor = {
             .offset = (VkOffset2D){0, 0},
             .extent = destImage->extent,
     };
 
-    logicalDevice->vkCmdSetScissor(logicalDevice->commandBuffer, 0, 1, &scissor);
-    logicalDevice->vkCmdBindDescriptorSets(logicalDevice->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                logicalDevice->fillTexturePoly->pipelineLayout, 0, 1, &logicalDevice->fillTexturePoly->descriptorSets, 0, NULL);
-    logicalDevice->vkCmdDraw(logicalDevice->commandBuffer, vertexNum, 1, 0, 0);
+    device->vkCmdSetScissor(device->commandBuffer, 0, 1, &scissor);
+    device->vkCmdBindDescriptorSets(device->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                device->fillTexturePoly->pipelineLayout, 0, 1, &device->fillTexturePoly->descriptorSets, 0, NULL);
+    device->vkCmdDraw(device->commandBuffer, vertexNum, 1, 0, 0);
 
-    logicalDevice->vkCmdEndRenderPass(logicalDevice->commandBuffer);
+    device->vkCmdEndRenderPass(device->commandBuffer);
 
 
 }
 
-void VKRenderer_ColorRender(VKLogicalDevice* logicalDevice, VKImage *destImage, VKRenderer *renderer, uint32_t rgba,
+void VKRenderer_ColorRender(VKDevice* device, VKImage *destImage, VKRenderer *renderer, uint32_t rgba,
                             VkBuffer vertexBuffer,
                             uint32_t vertexNum)
 {
@@ -666,17 +666,17 @@ void VKRenderer_ColorRender(VKLogicalDevice* logicalDevice, VKImage *destImage, 
         J2dRlsTrace(J2D_TRACE_ERROR, "VKRenderer_ColorRender: vertex buffer is NULL\n")
         return;
     }
-    logicalDevice->vkWaitForFences(logicalDevice->device, 1, &logicalDevice->inFlightFence, VK_TRUE, UINT64_MAX);
-    logicalDevice->vkResetFences(logicalDevice->device, 1, &logicalDevice->inFlightFence);
+    device->vkWaitForFences(device->device, 1, &device->inFlightFence, VK_TRUE, UINT64_MAX);
+    device->vkResetFences(device->device, 1, &device->inFlightFence);
 
-    logicalDevice->vkResetCommandBuffer(logicalDevice->commandBuffer, 0);
+    device->vkResetCommandBuffer(device->commandBuffer, 0);
 
-    VKRenderer_BeginRendering(logicalDevice);
+    VKRenderer_BeginRendering(device);
 
     VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
     VkRenderPassBeginInfo renderPassInfo = {
             .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-            .renderPass = logicalDevice->renderPass,
+            .renderPass = device->renderPass,
             .framebuffer = destImage->framebuffer,
             .renderArea.offset = (VkOffset2D){0, 0},
             .renderArea.extent = destImage->extent,
@@ -684,8 +684,8 @@ void VKRenderer_ColorRender(VKLogicalDevice* logicalDevice, VKImage *destImage, 
             .pClearValues = &clearColor
     };
 
-    logicalDevice->vkCmdBeginRenderPass(logicalDevice->commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
-    logicalDevice->vkCmdBindPipeline(logicalDevice->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+    device->vkCmdBeginRenderPass(device->commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+    device->vkCmdBindPipeline(device->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
                           renderer->graphicsPipeline);
     struct PushConstants {
         float r, g, b, a;
@@ -693,8 +693,8 @@ void VKRenderer_ColorRender(VKLogicalDevice* logicalDevice, VKImage *destImage, 
 
     pushConstants = (struct PushConstants){RGBA_TO_L4(rgba)};
 
-    logicalDevice->vkCmdPushConstants(
-            logicalDevice->commandBuffer,
+    device->vkCmdPushConstants(
+            device->commandBuffer,
             renderer->pipelineLayout,
             VK_SHADER_STAGE_VERTEX_BIT,
             0,
@@ -704,7 +704,7 @@ void VKRenderer_ColorRender(VKLogicalDevice* logicalDevice, VKImage *destImage, 
 
     VkBuffer vertexBuffers[] = {vertexBuffer};
     VkDeviceSize offsets[] = {0};
-    logicalDevice->vkCmdBindVertexBuffers(logicalDevice->commandBuffer, 0, 1, vertexBuffers, offsets);
+    device->vkCmdBindVertexBuffers(device->commandBuffer, 0, 1, vertexBuffers, offsets);
     VkViewport viewport = {
             .x = 0.0f,
             .y = 0.0f,
@@ -714,25 +714,25 @@ void VKRenderer_ColorRender(VKLogicalDevice* logicalDevice, VKImage *destImage, 
             .maxDepth = 1.0f
     };
 
-    logicalDevice->vkCmdSetViewport(logicalDevice->commandBuffer, 0, 1, &viewport);
+    device->vkCmdSetViewport(device->commandBuffer, 0, 1, &viewport);
 
     VkRect2D scissor = {
             .offset = (VkOffset2D){0, 0},
             .extent = destImage->extent,
     };
 
-    logicalDevice->vkCmdSetScissor(logicalDevice->commandBuffer, 0, 1, &scissor);
-    logicalDevice->vkCmdDraw(logicalDevice->commandBuffer, vertexNum, 1, 0, 0);
+    device->vkCmdSetScissor(device->commandBuffer, 0, 1, &scissor);
+    device->vkCmdDraw(device->commandBuffer, vertexNum, 1, 0, 0);
 
-    logicalDevice->vkCmdEndRenderPass(logicalDevice->commandBuffer);
-    VKRenderer_EndRendering(logicalDevice, VK_FALSE, VK_FALSE);
+    device->vkCmdEndRenderPass(device->commandBuffer);
+    VKRenderer_EndRendering(device, VK_FALSE, VK_FALSE);
 }
 
-void VKRenderer_ColorRenderMaxRect(VKLogicalDevice* logicalDevice, VKImage *destImage, uint32_t rgba) {
+void VKRenderer_ColorRenderMaxRect(VKDevice* device, VKImage *destImage, uint32_t rgba) {
     VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
     VkRenderPassBeginInfo renderPassInfo = {
             .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,
-            .renderPass = logicalDevice->renderPass,
+            .renderPass = device->renderPass,
             .framebuffer = destImage->framebuffer,
             .renderArea.offset = (VkOffset2D){0, 0},
             .renderArea.extent = destImage->extent,
@@ -740,9 +740,9 @@ void VKRenderer_ColorRenderMaxRect(VKLogicalDevice* logicalDevice, VKImage *dest
             .pClearValues = &clearColor
     };
 
-    logicalDevice->vkCmdBeginRenderPass(logicalDevice->commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
-    logicalDevice->vkCmdBindPipeline(logicalDevice->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                          logicalDevice->fillMaxColorPoly->graphicsPipeline);
+    device->vkCmdBeginRenderPass(device->commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
+    device->vkCmdBindPipeline(device->commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                          device->fillMaxColorPoly->graphicsPipeline);
 
     struct PushConstants {
         float r, g, b, a;
@@ -750,9 +750,9 @@ void VKRenderer_ColorRenderMaxRect(VKLogicalDevice* logicalDevice, VKImage *dest
 
     pushConstants = (struct PushConstants){RGBA_TO_L4(rgba)};
 
-    logicalDevice->vkCmdPushConstants(
-            logicalDevice->commandBuffer,
-            logicalDevice->fillMaxColorPoly->pipelineLayout,
+    device->vkCmdPushConstants(
+            device->commandBuffer,
+            device->fillMaxColorPoly->pipelineLayout,
             VK_SHADER_STAGE_VERTEX_BIT,
             0,
             sizeof(struct PushConstants),
@@ -768,21 +768,21 @@ void VKRenderer_ColorRenderMaxRect(VKLogicalDevice* logicalDevice, VKImage *dest
             .maxDepth = 1.0f
     };
 
-    logicalDevice->vkCmdSetViewport(logicalDevice->commandBuffer, 0, 1, &viewport);
+    device->vkCmdSetViewport(device->commandBuffer, 0, 1, &viewport);
 
     VkRect2D scissor = {
             .offset = (VkOffset2D){0, 0},
             .extent = destImage->extent,
     };
 
-    logicalDevice->vkCmdSetScissor(logicalDevice->commandBuffer, 0, 1, &scissor);
-    logicalDevice->vkCmdDraw(logicalDevice->commandBuffer, 4, 1, 0, 0);
+    device->vkCmdSetScissor(device->commandBuffer, 0, 1, &scissor);
+    device->vkCmdDraw(device->commandBuffer, 4, 1, 0, 0);
 
-    logicalDevice->vkCmdEndRenderPass(logicalDevice->commandBuffer);
+    device->vkCmdEndRenderPass(device->commandBuffer);
 }
 
 void
-VKRenderer_FillRect(VKLogicalDevice* logicalDevice, jint x, jint y, jint w, jint h)
+VKRenderer_FillRect(VKDevice* device, jint x, jint y, jint w, jint h)
 {
     J2dTraceLn4(J2D_TRACE_INFO, "VKRenderer_FillRect %d %d %d %d", x, y, w, h);
 
@@ -791,7 +791,7 @@ VKRenderer_FillRect(VKLogicalDevice* logicalDevice, jint x, jint y, jint w, jint
     }
 }
 
-void VKRenderer_RenderParallelogram(VKLogicalDevice* logicalDevice,
+void VKRenderer_RenderParallelogram(VKDevice* device,
                                   VKRenderer* renderer,
                                   jint color, VKSDOps *dstOps,
                                   jfloat x11, jfloat y11,
@@ -850,17 +850,17 @@ void VKRenderer_RenderParallelogram(VKLogicalDevice* logicalDevice,
 
     int vertexNum = ARRAY_SIZE(vertices);
 
-    VKBuffer* renderVertexBuffer = ARRAY_TO_VERTEX_BUF(logicalDevice, vertices);
+    VKBuffer* renderVertexBuffer = ARRAY_TO_VERTEX_BUF(device, vertices);
     ARRAY_FREE(vertices);
 
     VKRenderer_ColorRender(
-            logicalDevice,
+            device,
             vksdOps->image, renderer,
             color,
             renderVertexBuffer->buffer, vertexNum);
 }
 
-void VKRenderer_FillSpans(VKLogicalDevice* logicalDevice, jint color, VKSDOps *dstOps, jint spanCount, jint *spans)
+void VKRenderer_FillSpans(VKDevice* device, jint color, VKSDOps *dstOps, jint spanCount, jint *spans)
 {
     if (dstOps == NULL) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "VKRenderer_FillSpans: current dest is null");
@@ -907,7 +907,7 @@ void VKRenderer_FillSpans(VKLogicalDevice* logicalDevice, jint color, VKSDOps *d
         ARRAY_PUSH_BACK(&vertices, ((VKVertex){p1x,p1y}));
     }
 
-    VKBuffer *fillVertexBuffer = ARRAY_TO_VERTEX_BUF(logicalDevice, vertices);
+    VKBuffer *fillVertexBuffer = ARRAY_TO_VERTEX_BUF(device, vertices);
     if (!fillVertexBuffer) {
         J2dRlsTrace(J2D_TRACE_ERROR, "Cannot create vertex buffer\n")
         return;
@@ -915,21 +915,21 @@ void VKRenderer_FillSpans(VKLogicalDevice* logicalDevice, jint color, VKSDOps *d
     ARRAY_FREE(vertices);
 
     VKRenderer_ColorRender(
-            logicalDevice,
-            vksdOps->image, logicalDevice->fillColorPoly,
+            device,
+            vksdOps->image, device->fillColorPoly,
             color,
             fillVertexBuffer->buffer, VERT_COUNT);
 }
 
-jboolean VK_CreateLogicalDeviceRenderers(VKLogicalDevice* logicalDevice) {
-    logicalDevice->fillTexturePoly = VKRenderer_CreateFillTexturePoly(logicalDevice);
-    logicalDevice->fillColorPoly = VKRenderer_CreateRenderColorPoly(logicalDevice, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+jboolean VK_CreateLogicalDeviceRenderers(VKDevice* device) {
+    device->fillTexturePoly = VKRenderer_CreateFillTexturePoly(device);
+    device->fillColorPoly = VKRenderer_CreateRenderColorPoly(device, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
                                                                     VK_POLYGON_MODE_FILL);
-    logicalDevice->drawColorPoly = VKRenderer_CreateRenderColorPoly(logicalDevice, VK_PRIMITIVE_TOPOLOGY_LINE_STRIP,
+    device->drawColorPoly = VKRenderer_CreateRenderColorPoly(device, VK_PRIMITIVE_TOPOLOGY_LINE_STRIP,
                                                                     VK_POLYGON_MODE_LINE);
-    logicalDevice->fillMaxColorPoly = VKRenderer_CreateFillMaxColorPoly(logicalDevice);
-    if (!logicalDevice->fillTexturePoly || !logicalDevice->fillColorPoly || !logicalDevice->drawColorPoly ||
-        !logicalDevice->fillMaxColorPoly)
+    device->fillMaxColorPoly = VKRenderer_CreateFillMaxColorPoly(device);
+    if (!device->fillTexturePoly || !device->fillColorPoly || !device->drawColorPoly ||
+        !device->fillMaxColorPoly)
     {
         return JNI_FALSE;
     }

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKRenderer.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKRenderer.h
@@ -42,35 +42,35 @@ struct VKRenderer {
     VkPrimitiveTopology primitiveTopology;
 };
 
-VKRenderer *VKRenderer_CreateRenderColorPoly(VKLogicalDevice* logicalDevice, VkPrimitiveTopology primitiveTopology, VkPolygonMode polygonMode);
+VKRenderer *VKRenderer_CreateRenderColorPoly(VKDevice* device, VkPrimitiveTopology primitiveTopology, VkPolygonMode polygonMode);
 
-VKRenderer* VKRenderer_CreateFillTexturePoly(VKLogicalDevice* logicalDevice);
+VKRenderer* VKRenderer_CreateFillTexturePoly(VKDevice* device);
 
-VKRenderer* VKRenderer_CreateFillMaxColorPoly(VKLogicalDevice* logicalDevice);
+VKRenderer* VKRenderer_CreateFillMaxColorPoly(VKDevice* device);
 
-void VKRenderer_BeginRendering(VKLogicalDevice* logicalDevice);
+void VKRenderer_BeginRendering(VKDevice* device);
 
-void VKRenderer_EndRendering(VKLogicalDevice* logicalDevice,
+void VKRenderer_EndRendering(VKDevice* device,
                              VkBool32 notifyRenderFinish, VkBool32 waitForDisplayImage);
 
-void VKRenderer_TextureRender(VKLogicalDevice* logicalDevice,
+void VKRenderer_TextureRender(VKDevice* device,
                               VKImage *destImage, VKImage *srcImage,
                               VkBuffer vertexBuffer, uint32_t vertexNum);
 
-void VKRenderer_ColorRender(VKLogicalDevice* logicalDevice,
+void VKRenderer_ColorRender(VKDevice* device,
                             VKImage *destImage,
                             VKRenderer *renderer, uint32_t rgba, VkBuffer vertexBuffer, uint32_t vertexNum);
 
-void VKRenderer_ColorRenderMaxRect(VKLogicalDevice* logicalDevice, VKImage *destImage, uint32_t rgba);
+void VKRenderer_ColorRenderMaxRect(VKDevice* device, VKImage *destImage, uint32_t rgba);
 // fill ops
-void VKRenderer_FillRect(VKLogicalDevice* logicalDevice, jint x, jint y, jint w, jint h);
-void VKRenderer_RenderParallelogram(VKLogicalDevice* logicalDevice,
+void VKRenderer_FillRect(VKDevice* device, jint x, jint y, jint w, jint h);
+void VKRenderer_RenderParallelogram(VKDevice* device,
                                     VKRenderer* renderer, jint color, VKSDOps *dstOps,
                                     jfloat x11, jfloat y11,
                                     jfloat dx21, jfloat dy21,
                                     jfloat dx12, jfloat dy12);
 
-void VKRenderer_FillSpans(VKLogicalDevice* logicalDevice, jint color, VKSDOps *dstOps, jint spanCount, jint *spans);
+void VKRenderer_FillSpans(VKDevice* device, jint color, VKSDOps *dstOps, jint spanCount, jint *spans);
 
-jboolean VK_CreateLogicalDeviceRenderers(VKLogicalDevice* logicalDevice);
+jboolean VK_CreateLogicalDeviceRenderers(VKDevice* device);
 #endif //VKRenderer_h_Included

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKSurfaceData.c
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKSurfaceData.c
@@ -34,13 +34,13 @@
 #include "VKRenderer.h"
 #include <Trace.h>
 
-void VKSD_InitImageSurface(VKLogicalDevice* logicalDevice, VKSDOps *vksdo) {
+void VKSD_InitImageSurface(VKDevice* device, VKSDOps *vksdo) {
     if (vksdo->image != VK_NULL_HANDLE) {
         return;
     }
 
-    vksdo->device = logicalDevice;
-    vksdo->image = VKImage_Create(logicalDevice, vksdo->width, vksdo->height, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_LINEAR,
+    vksdo->device = device;
+    vksdo->image = VKImage_Create(device, vksdo->width, vksdo->height, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_LINEAR,
                                   VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
                                   VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!vksdo->image)
@@ -49,15 +49,15 @@ void VKSD_InitImageSurface(VKLogicalDevice* logicalDevice, VKSDOps *vksdo) {
         return;
     }
 
-    if (!VKImage_CreateFramebuffer(logicalDevice, vksdo->image, logicalDevice->renderPass)) {
+    if (!VKImage_CreateFramebuffer(device, vksdo->image, device->renderPass)) {
         J2dRlsTraceLn(J2D_TRACE_ERROR, "Cannot create framebuffer for window surface")
         return;
     }
 }
 
-void VKSD_InitWindowSurface(VKLogicalDevice* logicalDevice, VKWinSDOps *vkwinsdo) {
+void VKSD_InitWindowSurface(VKDevice* device, VKWinSDOps *vkwinsdo) {
     VKGraphicsEnvironment* ge = VKGE_graphics_environment();
-    VkPhysicalDevice physicalDevice = logicalDevice->physicalDevice;
+    VkPhysicalDevice physicalDevice = device->physicalDevice;
 
     if (vkwinsdo->swapchainKhr == VK_NULL_HANDLE) {
         ge->vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, vkwinsdo->surface, &vkwinsdo->capabilitiesKhr);
@@ -109,14 +109,14 @@ void VKSD_InitWindowSurface(VKLogicalDevice* logicalDevice, VKWinSDOps *vkwinsdo
                 .clipped = VK_TRUE
         };
 
-        if (logicalDevice->vkCreateSwapchainKHR(logicalDevice->device, &createInfoKhr, NULL, &vkwinsdo->swapchainKhr) != VK_SUCCESS) {
+        if (device->vkCreateSwapchainKHR(device->device, &createInfoKhr, NULL, &vkwinsdo->swapchainKhr) != VK_SUCCESS) {
             J2dRlsTrace(J2D_TRACE_ERROR, "Cannot create swapchain\n");
             return;
         }
 
         vkwinsdo->swapChainImages = VKImage_CreateImageArrayFromSwapChain(
-                                        logicalDevice, vkwinsdo->swapchainKhr,
-                                        logicalDevice->renderPass,
+                                        device, vkwinsdo->swapchainKhr,
+                                        device->renderPass,
                                         vkwinsdo->formatsKhr[0].format, extent);
 
         if (!vkwinsdo->swapChainImages) {

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKSurfaceData.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKSurfaceData.h
@@ -53,7 +53,7 @@ typedef struct {
     uint32_t                scale; // TODO Is it needed there at all?
     uint32_t                bgColor;
     VkBool32                bgColorUpdated;
-    VKLogicalDevice*        device;
+    VKDevice*               device;
     VKImage*                image;
     // We track any access and write access separately, as read-read access does not need synchronization.
     VkPipelineStageFlagBits lastStage;
@@ -96,7 +96,7 @@ void VKSD_Unlock(JNIEnv *env,
 void VKSD_Dispose(JNIEnv *env, SurfaceDataOps *ops);
 void VKSD_Delete(JNIEnv *env, VKSDOps *oglsdo);
 
-void VKSD_InitImageSurface(VKLogicalDevice* logicalDevice, VKSDOps *vksdo);
-void VKSD_InitWindowSurface(VKLogicalDevice* logicalDevice, VKWinSDOps *vkwinsdo);
+void VKSD_InitImageSurface(VKDevice* device, VKSDOps *vksdo);
+void VKSD_InitWindowSurface(VKDevice* device, VKWinSDOps *vkwinsdo);
 
 #endif /* VKSurfaceData_h_Included */

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKTexturePool.c
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKTexturePool.c
@@ -81,7 +81,7 @@ static ATexturePrivPtr* VKTexturePool_createTexture(ADevicePrivPtr *device,
                                                     long format)
 {
     CHECK_NULL_RETURN(device, NULL);
-    VKImage* texture = VKImage_Create((VKLogicalDevice*)device, width, height,
+    VKImage* texture = VKImage_Create((VKDevice*)device, width, height,
                                       (VkFormat)format,
                                       VK_IMAGE_TILING_LINEAR,
                                       VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
@@ -117,7 +117,7 @@ static void VKTexturePool_freeTexture(ADevicePrivPtr *device, ATexturePrivPtr *t
     if (TRACE_TEX) J2dRlsTraceLn4(J2D_TRACE_VERBOSE, "VKTexturePool_freeTexture: free texture: tex=%p, w=%d h=%d, pf=%d",
                                   tex, tex->extent.width, tex->extent.height, tex->format);
 
-    VKImage_free((VKLogicalDevice*)device, tex);
+    VKImage_free((VKDevice*)device, tex);
 }
 
 /* VKTexturePoolHandle API */
@@ -139,7 +139,7 @@ jint VKTexturePoolHandle_GetRequestedHeight(VKTexturePoolHandle *handle) {
 
 
 /* VKTexturePool API */
-VKTexturePool* VKTexturePool_initWithDevice(VKLogicalDevice *device) {
+VKTexturePool* VKTexturePool_initWithDevice(VKDevice *device) {
     CHECK_NULL_RETURN(device, NULL);
     // TODO: get vulkan device memory information (1gb fixed here):
     uint64_t maxDeviceMemory = 1024 * UNIT_MB;

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKTexturePool.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKTexturePool.h
@@ -45,7 +45,7 @@ jint VKTexturePoolHandle_GetRequestedHeight(VKTexturePoolHandle *handle);
 /* VKTexturePool API */
 typedef ATexturePool VKTexturePool;
 
-VKTexturePool* VKTexturePool_initWithDevice(VKLogicalDevice *device) ;
+VKTexturePool* VKTexturePool_initWithDevice(VKDevice *device) ;
 
 void VKTexturePool_Dispose(VKTexturePool *pool);
 

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKTypes.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKTypes.h
@@ -30,7 +30,7 @@
 typedef char* pchar;
 
 STRUCT(VKGraphicsEnvironment);
-STRUCT(VKLogicalDevice);
+STRUCT(VKDevice);
 STRUCT(VKRenderer);
 STRUCT(VKBuffer);
 STRUCT(VKImage);

--- a/src/java.desktop/share/native/common/java2d/vulkan/VKVertex.h
+++ b/src/java.desktop/share/native/common/java2d/vulkan/VKVertex.h
@@ -35,8 +35,8 @@
     ((c) & 0xFF)/255.0f,           \
     (((c) >> 24) & 0xFF)/255.0f
 
-#define ARRAY_TO_VERTEX_BUF(logicalDevice, vertices)                                           \
-    VKBuffer_CreateFromData(logicalDevice, vertices, ARRAY_SIZE(vertices)*sizeof (vertices[0]))
+#define ARRAY_TO_VERTEX_BUF(device, vertices)                                           \
+    VKBuffer_CreateFromData(device, vertices, ARRAY_SIZE(vertices)*sizeof (vertices[0]))
 
 typedef struct {
     VkVertexInputAttributeDescription *attributeDescriptions;


### PR DESCRIPTION
There is an inconsistency within our Vulkan implementation when it comes to naming of the device. Somewhere it's called "logicalDevice" and somewhere just "device". Let's make our naming consistent with Vulkan types, there is no "logical device", there's just "device" and "physical device"