### PR TITLE
vpr/main_8338411

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -865,7 +865,6 @@ jdk_awt_wayland = \
     -java/awt/event \
     -java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java \
     -java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java \
-    -java/awt/EventDispatchThread/PropertyPermissionOnEDT/PropertyPermissionOnEDT.java \
     -java/awt/EventQueue/6980209/bug6980209.java \
     -java/awt/FileDialog \
     -java/awt/FlowLayout \
@@ -888,7 +887,6 @@ jdk_awt_wayland = \
     -java/awt/Focus/ClearGlobalFocusOwnerTest \
     -java/awt/Focus/ClearLwQueueBreakTest \
     -java/awt/Focus/ClearMostRecentFocusOwnerTest.java \
-    -java/awt/Focus/CloseDialogActivateOwnerTest \
     -java/awt/Focus/ComponentLostFocusTest.java \
     -java/awt/Focus/ConsumedTabKeyTest.java \
     -java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest \
@@ -962,7 +960,6 @@ jdk_awt_wayland = \
     -java/awt/font/TextLayout/TestTibetan.java \
     -java/awt/font/TextLayout/TestVS.java \
     -java/awt/font/TextLayout/VariationSelectorTest.java \
-    -java/awt/FontClass/FontAccess.java \
     -java/awt/Frame \
     -java/awt/FullScreen/8013581 \
     -java/awt/FullScreen/AllFramesMaximize \
@@ -1034,7 +1031,6 @@ jdk_awt_wayland = \
     -java/awt/Robot \
     -java/awt/Scrollbar \
     -java/awt/ScrollPane \
-    -java/awt/security \
     -java/awt/SplashScreen \
     -java/awt/TextArea \
     -java/awt/TextComponent \
@@ -1047,7 +1043,6 @@ jdk_awt_wayland = \
     -java/awt/Toolkit/LockingKeyStateTest/LockingKeyStateTest.java \
     -java/awt/Toolkit/RealSync/Test.java \
     -java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java \
-    -java/awt/Toolkit/SecurityTest/SecurityTest2.java \
     -java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java \
     -java/awt/TrayIcon \
     -java/awt/wakefield \


### PR DESCRIPTION
8338411 removes the following tests including in Wayland groups that causes test runs to fail 

javax/swing/JFileChooser/6570445/bug6570445.java
javax/swing/JFileChooser/6738668/bug6738668.java
javax/swing/JFileChooser/7036025/bug7036025.java
javax/swing/JFileChooser/ShellFolderQueries/ShellFolderQueriesSecurityManagerTest.java
javax/swing/JPopupMenu/6675802/bug6675802.java
javax/swing/plaf/synth/Test8043627.java
javax/swing/text/rtf/bug4178276.java
java/awt/EventDispatchThread/PropertyPermissionOnEDT/PropertyPermissionOnEDT.java
java/awt/Focus/CloseDialogActivateOwnerTest
java/awt/FontClass/FontAccess.java
java/awt/security
java/awt/Toolkit/SecurityTest/SecurityTest2.java