### PR TITLE
JBR-8039 Fix NPE during initalization of ZipFile through FileSystems.getDefault

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -53,6 +53,7 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.CodeSource;
 import java.security.PrivilegedAction;
+import java.nio.file.FileSystems;
 import java.security.ProtectionDomain;
 import java.util.Collections;
 import java.util.List;
@@ -2325,6 +2326,8 @@ public final class System {
         }
 
         initialErrStream = System.err;
+
+        FileSystems.getDefault();
 
         // initializing the system class loader
         VM.initLevel(3);

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -36,9 +36,12 @@ import java.lang.ref.Cleaner.Cleanable;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
-import java.nio.file.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1576,18 +1579,7 @@ public class ZipFile implements ZipConstants, Closeable {
                 } else {
                     options = Set.of(StandardOpenOption.READ);
                 }
-                FileSystem defaultFileSystem = null;
-                try {
-                    defaultFileSystem = FileSystems.getDefault();
-                }
-                catch (NullPointerException ignored) {
-                    // NPE can be thrown during class loading, when the classloader tries to invoke ZipFile.
-                }
-                if (defaultFileSystem == null) {
-                    defaultFileSystem = DefaultFileSystemProvider.theFileSystem();
-                }
-                FileChannel channel = defaultFileSystem.provider()
-                        .newFileChannel(defaultFileSystem.getPath(key.file.toString()), options);
+                FileChannel channel = FileSystems.getDefault().provider().newFileChannel(key.file.toPath(), options);
                 if (channel instanceof FileChannelImpl) {
                     ((FileChannelImpl) channel).setUninterruptible();
                 }

--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -90,6 +90,20 @@ public class SetDefaultProvider {
         assertEquals(exitValue, 0);
     }
 
+    public void testClassPathWithFileSystemProviderJarAndNioForZipFile() throws Exception {
+        String testClasses = System.getProperty("test.classes");
+        Path fspJar = Path.of("testFileSystemProvider.jar");
+        Files.deleteIfExists(fspJar);
+        createFileSystemProviderJar(fspJar, Path.of(testClasses));
+
+        String jarFile = createModularJar();
+
+        String classpath = fspJar + File.pathSeparator + jarFile + File.pathSeparator + testClasses;
+        int exitValue = exec(SET_DEFAULT_FSP, "-Djava.util.zip.use.nio.for.zip.file.access=true",
+                "-cp", classpath, "p.Main");
+        assertEquals(exitValue, 0);
+    }
+
     /**
      * Creates a JAR containing the FileSystemProvider used to override the
      * default FileSystemProvider


### PR DESCRIPTION
In a case when `-Djava.nio.file.spi.DefaultFileSystemProvider` is specified and points to a class inside some JAR, this situation could happen:
* `ZipFile.<init>` tries to call `FileSystems.getDefault()`
* `FileSystems.getDefault()` calls `Class.forName()`
* `Class.forName()` calls `ZipFile.<init>`

This commit catches `NullPointerException` and switches to the original `FileSystem` in such cases.

The full stacktrace of the fixed error goes below:

```
java.lang.NullPointerException: Cannot invoke "java.nio.file.FileSystem.provider()" because the return value of "java.nio.file.FileSystems.getDefault()" is null
	at java.base/java.util.zip.ZipFile$Source.<init>(ZipFile.java:1582)
	at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1550)
	at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:734)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:261)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:190)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:345)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader.getJarFile(URLClassPath.java:809)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader$1.run(URLClassPath.java:774)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader$1.run(URLClassPath.java:768)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader.ensureOpen(URLClassPath.java:767)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader.<init>(URLClassPath.java:734)
	at java.base/jdk.internal.loader.URLClassPath$3.run(URLClassPath.java:497)
	at java.base/jdk.internal.loader.URLClassPath$3.run(URLClassPath.java:479)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
	at java.base/jdk.internal.loader.URLClassPath.getLoader(URLClassPath.java:478)
	at java.base/jdk.internal.loader.URLClassPath.getLoader(URLClassPath.java:446)
	at java.base/jdk.internal.loader.URLClassPath.getResource(URLClassPath.java:315)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:757)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at java.base/java.nio.file.FileSystems$DefaultFileSystemHolder.getDefaultProvider(FileSystems.java:124)
	at java.base/java.nio.file.FileSystems$DefaultFileSystemHolder$1.run(FileSystems.java:103)
	at java.base/java.nio.file.FileSystems$DefaultFileSystemHolder$1.run(FileSystems.java:101)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
	at java.base/java.nio.file.FileSystems$DefaultFileSystemHolder.defaultFileSystem(FileSystems.java:101)
	at java.base/java.nio.file.FileSystems$DefaultFileSystemHolder.<clinit>(FileSystems.java:94)
	at java.base/java.nio.file.FileSystems.getDefault(FileSystems.java:183)
	at java.base/java.util.zip.ZipFile$Source.<init>(ZipFile.java:1582)
	at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1550)
	at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:734)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:261)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:190)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:345)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader.getJarFile(URLClassPath.java:809)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader$1.run(URLClassPath.java:774)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader$1.run(URLClassPath.java:768)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader.ensureOpen(URLClassPath.java:767)
	at java.base/jdk.internal.loader.URLClassPath$JarLoader.<init>(URLClassPath.java:734)
	at java.base/jdk.internal.loader.URLClassPath$3.run(URLClassPath.java:497)
	at java.base/jdk.internal.loader.URLClassPath$3.run(URLClassPath.java:479)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
	at java.base/jdk.internal.loader.URLClassPath.getLoader(URLClassPath.java:478)
	at java.base/jdk.internal.loader.URLClassPath.getLoader(URLClassPath.java:446)
	at java.base/jdk.internal.loader.URLClassPath.getResource(URLClassPath.java:315)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:757)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3578)
	at java.base/java.lang.Class.getMethodsRecursive(Class.java:3719)
	at java.base/java.lang.Class.getMethod0(Class.java:3705)
	at java.base/java.lang.Class.getMethod(Class.java:2393)
	at java.base/jdk.internal.misc.MainMethodFinder.findMainMethod(MainMethodFinder.java:146)
	at java.base/sun.launcher.LauncherHelper.validateMainClass(LauncherHelper.java:888)
	at java.base/sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:726)
```