### PR TITLE
JBR-8043 Fix CSE from Files.probeContentType with overridden DefaultFileSystemProvider

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
+++ b/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
@@ -25,7 +25,9 @@
 
 package sun.nio.fs;
 
+import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.nio.file.spi.FileTypeDetector;
 import java.nio.file.spi.FileSystemProvider;
 
@@ -34,6 +36,14 @@ public class DefaultFileTypeDetector {
 
     public static FileTypeDetector create() {
         FileSystemProvider provider = FileSystems.getDefault().provider();
-        return ((UnixFileSystemProvider)provider).getFileTypeDetector();
+        if (provider instanceof UnixFileSystemProvider) {
+            return ((UnixFileSystemProvider)provider).getFileTypeDetector();
+        }
+        return new FileTypeDetector() {
+            @Override
+            public String probeContentType(Path path) throws IOException {
+                return null;
+            }
+        };
     }
 }

--- a/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
+++ b/src/java.base/unix/classes/sun/nio/fs/DefaultFileTypeDetector.java
@@ -36,8 +36,8 @@ public class DefaultFileTypeDetector {
 
     public static FileTypeDetector create() {
         FileSystemProvider provider = FileSystems.getDefault().provider();
-        if (provider instanceof UnixFileSystemProvider) {
-            return ((UnixFileSystemProvider)provider).getFileTypeDetector();
+        if (provider instanceof UnixFileSystemProvider unixProvider) {
+            return unixProvider.getFileTypeDetector();
         }
         return new FileTypeDetector() {
             @Override


### PR DESCRIPTION
Before this commit, the code `DefaultFileTypeDetector` implied that the default file system provider is always an instance of `UnixFileSystemProvider`. It's not true when `-Djava.nio.file.spi.DefaultFileSystemProvider` is specified.

In general, there's a possibility to specify a custom `FileTypeDetector` and define it via service loading. (See `java.nio.file.Files.probeContentType`). However, the problematic code is invoked during the static initialization of the class `java.nio.file.Files.FileTypeDetectors`, which is also the entry point for the service loader. This way, it's even impossible to define a custom `FileTypeDetector`.

This commit replaces the strict class cast with a conditional one, and the new code returns a no-op file type detector in cases when the default file system provider is overridden.