### PR TITLE
Don't throw ArrayIndexOutOfBoundsException from FileSystemProvider.newByteChannel on Unix

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
@@ -197,8 +197,9 @@ class UnixChannelFactory {
             if (flags.createNew) {
                 byte[] pathForSysCall = path.asByteArray();
 
-                // throw exception if file name is "." to avoid confusing error
-                if ((pathForSysCall[pathForSysCall.length-1] == '.') &&
+                // throw exception if file name is "." or "" to avoid confusing error
+                if ((pathForSysCall.length == 0) ||
+                    (pathForSysCall[pathForSysCall.length-1] == '.') &&
                     (pathForSysCall.length == 1 ||
                     (pathForSysCall[pathForSysCall.length-2] == '/')))
                 {

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -30,16 +30,17 @@
  */
 
 import java.io.IOException;
-import java.io.File;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.nio.file.attribute.UserPrincipal;
+import java.util.EnumSet;
 import java.util.List;
 import jdk.test.lib.Platform;
 
@@ -55,6 +56,7 @@ public class Misc {
             testIsSameFile(dir);
             testFileTypeMethods(dir);
             testAccessMethods(dir);
+            testEmptyPathForByteStream();
         } finally {
              TestUtil.removeAll(dir);
         }
@@ -360,6 +362,18 @@ public class Misc {
             }
         } finally {
             delete(file);
+        }
+    }
+
+    static void testEmptyPathForByteStream() throws IOException {
+        Path emptyPath = Path.of("");
+        try {
+            emptyPath.getFileSystem().provider()
+                    .newByteChannel(emptyPath, EnumSet.of(StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW))
+                    .close();
+            throw new RuntimeException("FileAlreadyExistsException was not thrown");
+        } catch (FileAlreadyExistsException e) {
+            // The expected behavior.
         }
     }
 


### PR DESCRIPTION
Due to a missed check, a call of `newByteChannel(Path.of(""), EnumSet.of(WRITE, CREATE_NEW))` led to `ArrayIndexOutOfBoundsException`, because there was no check for an empty path.

Now this code throws `FileAlreadyExists`, as it happens for other corner cases like `Path.of(".")"`