### PR TITLE
JBR-8216 Implement setAccessibilityValue method for NavigableTextAccessibility

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibleText.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibleText.java
@@ -373,4 +373,37 @@ class CAccessibleText {
             }
         }, c);
     }
+
+    static void setText(final Accessible a, final Component c, final String newText) {
+        if (a == null) return;
+
+        CAccessibility.invokeLater(new Runnable() {
+            public void run() {
+                final AccessibleContext ac = a.getAccessibleContext();
+                if (ac == null) return;
+
+                final AccessibleEditableText aet = ac.getAccessibleEditableText();
+                if (aet == null) return;
+
+                aet.setTextContents(newText);
+            }
+        }, c);
+    }
+
+    static boolean isSetAccessibilityValueAllowed(final Accessible a, final Component c) {
+        if (a == null) return false;
+
+        return CAccessibility.invokeAndWait(new Callable<Boolean>() {
+            public Boolean call() throws Exception {
+                final AccessibleContext ac = a.getAccessibleContext();
+                if (ac == null || ac.getAccessibleEditableText() == null) return false;
+
+                final Accessible sa = CAccessible.getSwingAccessible(a);
+                if (sa instanceof JTextComponent textComponent) {
+                    return textComponent.isEditable() && textComponent.isEnabled();
+                }
+                return false;
+            }
+        }, c, false);
+    }
 }


### PR DESCRIPTION
* This method allows for third-party tools to modify text component contents through the accessibility API on macOS;
* In the legacy JavaTextAccessibility.m, there were methods `accessibilityIsValueAttributeSettable` and `accessibilitySetValueAttribute`, but in the current implementation we need to implement `setAccessibilityValue` and `isAccessibilitySelectorAllowed`;
* The `setAccessibilityValue` method is implemented similarly to `NavigableTextAccessibility.setAccessibilitySelectedText`. On the Java side, it calls `AccessibleEditableText.setTextContents` according to the comment in `JavaTextAccessibility.accessibilitySetValueAttribute`;
* The `isAccessibilitySelectorAllowed` method is implemented similarly to `JavaTextAccessibility.accessibilityIsValueAttributeSettable`: it checks if the text component implements `AccessibleEditableText`, is enabled, and additionally checks if the editable property is true, because some components could be enabled but not editable, and we shouldn't allow setting the value in this case.

Demo of this feature in Accessibility Inspector tool:


https://github.com/user-attachments/assets/0eb759f5-9e01-48d2-9ef8-209ddd5876eb

It's possible to edit value only for editable text components. Before this change, the button to edit the value was not even showing.