### PR TITLE
JBR-8408 Post accessibility value changed events for scroll bars

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -405,7 +405,8 @@ class CAccessible extends CFRetainedResource implements Accessible {
                     AccessibleRole thisRole = accessible.getAccessibleContext()
                                                         .getAccessibleRole();
                     if (thisRole == AccessibleRole.SLIDER ||
-                            thisRole == AccessibleRole.PROGRESS_BAR) {
+                            thisRole == AccessibleRole.PROGRESS_BAR ||
+                            thisRole == AccessibleRole.SCROLL_BAR) {
                         execute(ptr -> valueChanged(ptr));
                     }
                 }


### PR DESCRIPTION
Third-party apps might want to subscribe for scroll bar value changed events to track scroll position. VoiceOver and Zoom don't react to these events. 

https://github.com/user-attachments/assets/36b3ee4b-75c7-447b-8c66-fa6e1e40cc7a

