### PR TITLE
JBR-8490 Improve searching for scroll bars in ScrollAreaAccessibility

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -67,6 +67,7 @@ import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JTextArea;
 import javax.swing.JList;
+import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
 
@@ -1095,5 +1096,24 @@ class CAccessibility implements PropertyChangeListener {
                 return false;
             }
         }, c, false);
+    }
+
+    private static Accessible getScrollBar(Accessible a, Component c, int orientation) {
+        if (a == null) return null;
+
+        return invokeAndWait(() -> {
+            Accessible sa = CAccessible.getSwingAccessible(a);
+            if (sa instanceof JScrollPane scrollPane) {
+                // NSAccessibilityOrientationVertical
+                if (orientation == 1) {
+                    return scrollPane.getVerticalScrollBar();
+                }
+                // NSAccessibilityOrientationHorizontal
+                else if (orientation == 2) {
+                    return scrollPane.getHorizontalScrollBar();
+                }
+            }
+            return null;
+        }, c);
     }
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
@@ -28,6 +28,9 @@
 #import "JNIUtilities.h"
 #import "sun_lwawt_macosx_CAccessibility.h"
 
+static jclass sjc_CAccessibility = NULL;
+static jmethodID sjm_getScrollBar = NULL;
+
 /*
  * Implementation of the accessibility peer for the ScrollArea role
  */
@@ -57,10 +60,30 @@
 {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
 
+    // Firstly, try to get the scroll bar using getHorizontalScrollBar/getVerticalScrollBar methods of JScrollPane.
+    jobject scrollBar = NULL;
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getScrollBar, sjc_CAccessibility, "getScrollBar",
+                             "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)Ljavax/accessibility/Accessible;", nil);
+    scrollBar = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getScrollBar, fAccessible, fComponent, orientation);
+    CHECK_EXCEPTION();
+
+    if (scrollBar != NULL) {
+        CommonComponentAccessibility *axScrollBar = nil;
+        DECLARE_CLASS_RETURN(sjc_Accessible, "javax/accessibility/Accessible", nil);
+        if ((*env)->IsInstanceOf(env, scrollBar, sjc_Accessible)) {
+            axScrollBar = [CommonComponentAccessibility createWithAccessible:scrollBar withEnv:env withView:fView];
+        }
+        (*env)->DeleteLocalRef(env, scrollBar);
+        if (axScrollBar != nil) {
+            return axScrollBar;
+        }
+    }
+
+    // Otherwise, try to search for the scroll bar within the children.
     NSArray *children = [CommonComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:sun_lwawt_macosx_CAccessibility_JAVA_AX_ALL_CHILDREN allowIgnored:YES];
     if ([children count] <= 0) return nil;
 
-    // The scroll bars are in the children.
     CommonComponentAccessibility *aElement;
     NSEnumerator *enumerator = [children objectEnumerator];
     while ((aElement = (CommonComponentAccessibility *)[enumerator nextObject])) {


### PR DESCRIPTION
Use `JScrollPane.getVerticalScrollBar/getHorizontalScrollBar` methods to look for scroll bars. In some cases a scroll bar might be not a direct child of the scroll area, but it can still be assigned to the vertical/horizontalScrollBar property.

For instance, this was the case for the Editor's scroll area in the IDE, and now the vertical scroll bar is set to the `accessibilityVerticalScrollBar` property.
<img width="1347" alt="Screenshot 2025-03-28 at 18 38 03" src="https://github.com/user-attachments/assets/084ead96-0ff6-4692-8bec-c7048d72644c" />
