### PR TITLE
Adding support for RTL Custom TitleBar

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/jbr_CustomTitleBarControls.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/jbr_CustomTitleBarControls.cpp
@@ -355,6 +355,7 @@ class CustomTitleBarControls::Style {
 public:
     float height {0}, width {0};
     int dark {0};
+    bool rtl {false};
     ButtonColors colors {};
 
     bool Update(jobject target, JNIEnv* env) {
@@ -369,6 +370,7 @@ public:
                 height = JNU_CallMethodByName(env, nullptr, titleBar, "getHeight", "()F").f;
                 width = GetNumberProperty(env, properties, L"controls.width");
                 dark = GetBooleanProperty(env, properties, L"controls.dark");
+                rtl = GetBooleanProperty(env, properties, L"controls.rtl") > 0;
                 // Get colors
                 #define GET_STATE_COLOR(NAME, PROPERTY) \
                 colors[0][(int)State::NAME] = GetColorProperty(env, properties, L"controls.background." PROPERTY); \
@@ -456,12 +458,15 @@ void CustomTitleBarControls::PaintButton(Type type, State state, int x, int widt
 
 #define LOAD_STYLE_BITS()                                        \
 DWORD styleBits = (DWORD) GetWindowLong(parent, GWL_STYLE);      \
-DWORD exStyleBits = (DWORD) GetWindowLong(parent, GWL_EXSTYLE);  \
-bool allButtons = styleBits & (WS_MINIMIZEBOX | WS_MAXIMIZEBOX); \
-bool ltr = !(exStyleBits & WS_EX_LAYOUTRTL)
+bool allButtons = styleBits & (WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
 
 void CustomTitleBarControls::Update(State windowState) {
     LOAD_STYLE_BITS();
+
+    // Updating orientation before rendering the controls
+    DWORD currentExStyle = (DWORD) GetWindowLong(hwnd, GWL_EXSTYLE);
+    if (style->rtl == !(currentExStyle & WS_EX_LAYOUTRTL))
+        ::SetWindowLongPtr(hwnd, GWL_EXSTYLE, currentExStyle ^ WS_EX_LAYOUTRTL);
 
     // Calculate size
     float userWidth;
@@ -499,22 +504,17 @@ void CustomTitleBarControls::Update(State windowState) {
     if (allButtons) {
         int w = newSize.cx / 3;
         Type maxType = IsZoomed(parent) ? Type::RESTORE : Type::MAXIMIZE;
-        if (ltr) {
-            PaintButton(Type::MINIMIZE, minState, 0, w, scale, dark);
-            PaintButton(maxType, maxState, w, w, scale, dark);
-            PaintButton(Type::CLOSE, closeState, w*2, newSize.cx-w*2, scale, dark);
-        } else {
-            PaintButton(Type::CLOSE, closeState, 0, newSize.cx-w*2, scale, dark);
-            PaintButton(maxType, maxState, newSize.cx-w*2, w, scale, dark);
-            PaintButton(Type::MINIMIZE, minState, newSize.cx-w, w, scale, dark);
-        }
+        
+        PaintButton(Type::MINIMIZE, minState, 0, w, scale, dark);
+        PaintButton(maxType, maxState, w, w, scale, dark);
+        PaintButton(Type::CLOSE, closeState, w*2, newSize.cx-w*2, scale, dark);
     } else {
         PaintButton(Type::CLOSE, closeState, 0, newSize.cx, scale, dark);
     }
 
     // Update window
     POINT position {0, 0}, ptSrc {0, 0};
-    if (ltr) {
+    if (!style->rtl) {
         RECT parentRect;
         GetClientRect(parent, &parentRect);
         position.x = parentRect.right - newSize.cx;
@@ -535,7 +535,7 @@ void CustomTitleBarControls::Update(State windowState) {
     JNIEnv *env = (JNIEnv *) JNU_GetEnv(jvm, JNI_VERSION_1_2);
     jobject target = env->NewLocalRef(this->target);
     if (target) {
-        env->CallVoidMethod(target, jmUpdateInsets, !ltr ? userWidth : 0.0f, ltr ? userWidth : 0.0f);
+        env->CallVoidMethod(target, jmUpdateInsets, style->rtl ? userWidth : 0.0f, !style->rtl ? userWidth : 0.0f);
         env->DeleteLocalRef(target);
     }
 }
@@ -551,9 +551,14 @@ LRESULT CustomTitleBarControls::Hit(HitType type, int ncx, int ncy) {
             if (allButtons) {
                 int w = (rect.right - rect.left) / 3;
                 ncx -= rect.left;
-                if (!ltr) ncx = rect.right - rect.left - ncx;
-                if (ncx < w) newHit = HTMINBUTTON;
-                else if (ncx < w*2) newHit = HTMAXBUTTON;
+
+                if (style->rtl) {
+                    if (ncx > w && ncx <= w*2) newHit = HTMAXBUTTON;
+                    else if (ncx > w*2 && ncx <= w*3) newHit = HTMINBUTTON;
+                } else {
+                    if (ncx < w) newHit = HTMINBUTTON;
+                    else if (ncx < w*2) newHit = HTMAXBUTTON;
+                }
             }
         }
     }


### PR DESCRIPTION
We had an issue reported on Jewel that the custom titlebar/decorated window did not support RTL alignment (https://github.com/JetBrains/intellij-community/pull/3087).

The initial solution involved hiding the controls and drawing them manually on the correct side. But as this is an issue with the title bar, we thought it would be better to fix inside the runtime.

# Solutions

While debugging the JBR, I found three possible solutions:

## Fixing the button orders

The first solution was simply usin the `WS_EX_LAYOUTRTL` and `WS_EX_RTLREADING` on the client side. However, the button orders did not match the expectations and hover/clicks were all bugged out. ([video](https://github.com/JetBrains/intellij-community/pull/3087#issuecomment-2958845896))

Even though this is a simple solution, it would still require the client app (or the Jewel library) to perform system calls to update the window. Here is a small snippet to perform this action from Kotlin:

```kotlin
public fun Window.setWindowsRtlLayout() {
    if (!hostOs.isWindows) return

    val isRtl = !this.componentOrientation.isLeftToRight
    // Obtain HWND from AWT component
    val hwnd = WinDef.HWND(Native.getComponentPointer(this))

    val current = User32.INSTANCE.GetWindowLongPtr(hwnd, GWL_EXSTYLE).toLong()
    val newStyle = if (isRtl) {
        current or WS_EX_LAYOUTRTL.toLong() or WS_EX_RTLREADING.toLong()
    } else {
        current and WS_EX_LAYOUTRTL.inv().toLong() and WS_EX_RTLREADING.inv().toLong()
    }

    if (newStyle != current) {
        User32.INSTANCE.SetWindowLongPtr(hwnd, GWL_EXSTYLE, LONG_PTR(newStyle))
        // Tell the window manager to re-evaluate styles
        User32.INSTANCE.SetWindowPos(
            hwnd, null, 0, 0, 0, 0,
            SWP_NOMOVE or SWP_NOSIZE or SWP_NOZORDER or SWP_FRAMECHANGED
        )
    }
}
```

## Add RTL flag as titlebar property (Current PR)

This solution is similar to the previous one. It still requires the "client" to pass the flag informing the RTL orientation. With this solution, we are able to achieve a solution that support RTL, without impacting the existing behavior and the IDEs.

In this implementations, even though the user forces the `WS_EX_LAYOUTRTL` flag, it will keep the buttons in the expected places (making the correction to placement and everything).

## Matching Swing

Swing and Compose use the user Locale to determine if it should render LTR or RTL. On Compose, we use the `GlobalLayoutDirection` (See [GlobalLayoutDirection](https://github.com/JetBrains/compose-multiplatform-core/blob/jb-main/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/LayoutConfiguration.desktop.kt#L61-L71)).

We could use the same logic on C++ with the following snippet:

```cpp
DWORD readingLayout; // Buffer for orientationAdd commentMore actions
int cchData = GetLocaleInfoEx(
  LOCALE_NAME_USER_DEFAULT,   // Use the user's default locale name
  LOCALE_IREADINGLAYOUT | LOCALE_RETURN_NUMBER,      // Get the reading layout for the locale
  (LPWSTR) &readingLayout,
  sizeof(readingLayout) / sizeof(WCHAR)
);

// cchData > 0 is a success result; Layout 1 or 3 means RTLAdd commentMore actions
this->rtl = cchData > 0 && (readingLayout == 1 || readingLayout == 3); Add comment
```

Even though this is the solution that achieves the best result, it would be the more invasive, changing the behavior on the IDE too.

# Evidences

> [!NOTE]
> This solution is only applied to the custom titlebar implementation. Default/AWT window controls were not changed

| LTR (en-us) | RTL (fa-ir) |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/035135ed-80a7-4585-8908-3c02933a99a9) | ![image](https://github.com/user-attachments/assets/2bca224f-d241-47f4-8288-b048d9f45b5b)
| ![image](https://github.com/user-attachments/assets/4e39c707-971f-416b-b473-48ff8bb59df3) | ![image](https://github.com/user-attachments/assets/39bab1f2-5c1a-4637-ae6e-08404d616c05)

Button hover state

| Before | After |
| --- | --- |
| ![Screen Recording 2025-06-18 at 7 33 29 PM](https://github.com/user-attachments/assets/e17f28d6-db03-4243-bc10-abdc2e7e7fba) | ![Screen Recording 2025-06-18 at 7 30 45 PM](https://github.com/user-attachments/assets/ec805d73-9639-4f5f-9cd9-9869acae90c7)

