### PR TITLE
metal: refactor shared textures

### DIFF
--- a/src/java.desktop/macosx/classes/com/jetbrains/desktop/SharedTexturesService.java
+++ b/src/java.desktop/macosx/classes/com/jetbrains/desktop/SharedTexturesService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 JetBrains s.r.o.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.jetbrains.desktop;
+
+import com.jetbrains.desktop.image.TextureWrapperSurfaceManager;
+import com.jetbrains.exported.JBRApi;
+import sun.awt.image.SurfaceManager;
+import sun.java2d.SurfaceData;
+import sun.java2d.metal.MTLGraphicsConfig;
+import sun.java2d.metal.MTLTextureWrapperSurfaceData;
+
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Image;
+
+@JBRApi.Service
+@JBRApi.Provides("SharedTextures")
+public class SharedTexturesService extends SharedTextures {
+    private final int textureType;
+
+    public SharedTexturesService() {
+        textureType = getTextureTypeImpl();
+        if (textureType == 0) {
+            throw new JBRApi.ServiceNotAvailableException();
+        }
+    }
+
+    @Override
+    public int getTextureType() {
+        return textureType;
+    }
+
+    private static int getTextureTypeImpl() {
+        GraphicsConfiguration gc = GraphicsEnvironment
+                .getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice()
+                .getDefaultConfiguration();
+
+        if (gc instanceof MTLGraphicsConfig) {
+            return METAL_TEXTURE_TYPE;
+        }
+
+        return 0;
+    }
+
+    @Override
+    protected SurfaceManager createSurfaceManager(GraphicsConfiguration gc, Image image, long texture) {
+        SurfaceData sd;
+        if (gc instanceof MTLGraphicsConfig mtlGraphicsConfig) {
+            sd = new MTLTextureWrapperSurfaceData(mtlGraphicsConfig, image, texture);
+        } else {
+            throw new IllegalArgumentException("Unsupported graphics configuration: " + gc);
+        }
+
+        return new TextureWrapperSurfaceManager(sd);
+    }
+}

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLGraphicsConfig.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLGraphicsConfig.java
@@ -31,7 +31,6 @@ import sun.awt.CGraphicsEnvironment;
 import sun.awt.image.OffScreenImage;
 import sun.awt.image.SunVolatileImage;
 import sun.awt.image.SurfaceManager;
-import sun.awt.image.TextureWrapperSurfaceManager;
 import sun.awt.image.VolatileSurfaceManager;
 import sun.java2d.Disposer;
 import sun.java2d.DisposerRecord;
@@ -49,7 +48,6 @@ import java.awt.BufferCapabilities;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.GraphicsConfiguration;
 import java.awt.Image;
 import java.awt.ImageCapabilities;
 import java.awt.Rectangle;
@@ -71,7 +69,7 @@ import static sun.java2d.pipe.hw.ContextCapabilities.*;
 import static sun.java2d.metal.MTLContext.MTLContextCaps.CAPS_EXT_BIOP_SHADER;
 
 public final class MTLGraphicsConfig extends CGraphicsConfig
-        implements AccelGraphicsConfig, SurfaceManager.Factory, SurfaceManager.TextureWrapperFactory
+        implements AccelGraphicsConfig, SurfaceManager.Factory
 {
     private static ImageCapabilities imageCaps = new MTLImageCaps();
 
@@ -381,12 +379,5 @@ public final class MTLGraphicsConfig extends CGraphicsConfig
     public VolatileSurfaceManager createVolatileManager(SunVolatileImage image,
                                                         Object context) {
         return new MTLVolatileSurfaceManager(image, context);
-    }
-
-    @Override
-    public SurfaceManager createTextureWrapperSurfaceManager(
-            GraphicsConfiguration gc, Image image, long texture) {
-        SurfaceData sd = MTLSurfaceData.createData(this, image, texture);
-        return new TextureWrapperSurfaceManager(sd);
     }
 }

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceData.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceData.java
@@ -50,7 +50,6 @@ import java.awt.Transparency;
 
 import java.awt.image.ColorModel;
 import java.awt.image.Raster;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static sun.java2d.pipe.BufferedOpCodes.DISPOSE_SURFACE;
 import static sun.java2d.pipe.BufferedOpCodes.FLUSH_SURFACE;
@@ -152,7 +151,7 @@ public abstract class MTLSurfaceData extends SurfaceData
     private native void initOps(MTLGraphicsConfig gc, long pConfigInfo, long pPeerData, long layerPtr,
                                 int xoff, int yoff, boolean isOpaque);
 
-    private MTLSurfaceData(MTLLayer layer, MTLGraphicsConfig gc,
+    protected MTLSurfaceData(MTLLayer layer, MTLGraphicsConfig gc,
                            ColorModel cm, int type, int width, int height)
     {
         super(getCustomSurfaceType(type), cm);
@@ -201,10 +200,6 @@ public abstract class MTLSurfaceData extends SurfaceData
                 type);
     }
 
-    public static MTLTextureWrapperSurfaceData createData(MTLGraphicsConfig gc, Image image, long pTexture) {
-        return new MTLTextureWrapperSurfaceData(gc, image, pTexture);
-    }
-
     @Override
     public double getDefaultScaleX() {
         return scale;
@@ -223,8 +218,6 @@ public abstract class MTLSurfaceData extends SurfaceData
     protected native void clearWindow();
 
     protected native boolean initTexture(long pData, boolean isOpaque, int width, int height);
-
-    protected native boolean initWithTexture(long pData, boolean isOpaque, long texturePtr);
 
     protected native boolean initRTexture(long pData, boolean isOpaque, int width, int height);
 
@@ -689,46 +682,4 @@ public abstract class MTLSurfaceData extends SurfaceData
     }
 
     private static native boolean loadNativeRasterWithRects(long sdops, long pRaster, int width, int height, long pRects, int rectsCount);
-
-    /**
-     * Surface data for an existing texture
-     */
-    public static final class MTLTextureWrapperSurfaceData extends MTLSurfaceData {
-        private final Image myImage;
-
-        private MTLTextureWrapperSurfaceData(MTLGraphicsConfig gc, Image image, long pTexture) throws IllegalArgumentException {
-            super(null, gc, ColorModel.getRGBdefault(), RT_TEXTURE, /*width=*/ 0, /*height=*/ 0);
-            myImage = image;
-
-            MTLRenderQueue rq = MTLRenderQueue.getInstance();
-            AtomicBoolean success = new AtomicBoolean(false);
-
-            rq.lock();
-            try {
-                MTLContext.setScratchSurface(gc);
-                rq.flushAndInvokeNow(() -> success.set(initWithTexture(getNativeOps(), false, pTexture)));
-            } finally {
-                rq.unlock();
-            }
-
-            if (!success.get()) {
-                throw new IllegalArgumentException("Failed to init the surface data");
-            }
-        }
-
-        @Override
-        public SurfaceData getReplacement() {
-            throw new UnsupportedOperationException("not implemented");
-        }
-
-        @Override
-        public Object getDestination() {
-            return myImage;
-        }
-
-        @Override
-        public Rectangle getBounds() {
-            return getNativeBounds();
-        }
-    }
 }

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceDataExt.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceDataExt.java
@@ -1,0 +1,9 @@
+package sun.java2d.metal;
+
+public class MTLSurfaceDataExt {
+    public static boolean initWithTexture(MTLSurfaceData sd, long texturePtr) {
+        return initWithTexture(sd.getNativeOps(), false, texturePtr);
+    }
+
+    private static native boolean initWithTexture(long pData, boolean isOpaque, long texturePtr);
+}

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLTextureWrapperSurfaceData.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLTextureWrapperSurfaceData.java
@@ -1,0 +1,49 @@
+package sun.java2d.metal;
+
+import sun.java2d.SurfaceData;
+
+import java.awt.*;
+import java.awt.image.ColorModel;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Surface data for an existing texture
+ */
+public final class MTLTextureWrapperSurfaceData extends MTLSurfaceData {
+    private final Image myImage;
+
+    public MTLTextureWrapperSurfaceData(MTLGraphicsConfig gc, Image image, long pTexture) throws IllegalArgumentException {
+        super(null, gc, gc.getColorModel(TRANSLUCENT), RT_TEXTURE, /*width=*/ 0, /*height=*/ 0);
+        myImage = image;
+
+        MTLRenderQueue rq = MTLRenderQueue.getInstance();
+        AtomicBoolean success = new AtomicBoolean(false);
+
+        rq.lock();
+        try {
+            MTLContext.setScratchSurface(gc);
+            rq.flushAndInvokeNow(() -> success.set(MTLSurfaceDataExt.initWithTexture(this, pTexture)));
+        } finally {
+            rq.unlock();
+        }
+
+        if (!success.get()) {
+            throw new IllegalArgumentException("Failed to init the surface data");
+        }
+    }
+
+    @Override
+    public SurfaceData getReplacement() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Object getDestination() {
+        return myImage;
+    }
+
+    @Override
+    public Rectangle getBounds() {
+        return getNativeBounds();
+    }
+}

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
@@ -107,81 +107,6 @@ static jboolean MTLSurfaceData_initTexture(BMTLSDOps *bmtlsdo, jboolean isOpaque
     }
 }
 
-static jboolean MTLSurfaceData_initWithTexture(BMTLSDOps *bmtlsdo, jboolean isOpaque, void* pTexture) {
-    @autoreleasepool {
-        if (bmtlsdo == NULL) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: ops are null");
-            return JNI_FALSE;
-        }
-
-        if (pTexture == NULL) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: texture is null");
-            return JNI_FALSE;
-        }
-
-        id <MTLTexture> texture = (__bridge id <MTLTexture>) pTexture;
-        if (texture == NULL) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: failed to cast texture to MTLTexture");
-            return JNI_FALSE;
-        }
-
-        if (texture.width >= MTL_GPU_FAMILY_MAC_TXT_SIZE || texture.height >= MTL_GPU_FAMILY_MAC_TXT_SIZE ||
-            texture.width == 0 || texture.height == 0) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: wrong texture size %d x %d",
-                          texture.width, texture.height);
-            return JNI_FALSE;
-        }
-
-        if (texture.pixelFormat != MTLPixelFormatBGRA8Unorm) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: unsupported pixel format: %d",
-                          texture.pixelFormat);
-            return JNI_FALSE;
-        }
-
-        bmtlsdo->pTexture = texture;
-        bmtlsdo->pOutTexture = NULL;
-
-        MTLSDOps *mtlsdo = (MTLSDOps *)bmtlsdo->privOps;
-        if (mtlsdo == NULL) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: MTLSDOps are null");
-            return JNI_FALSE;
-        }
-        if (mtlsdo->configInfo == NULL || mtlsdo->configInfo->context == NULL) {
-            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: MTLSDOps wasn't initialized (context is null)");
-            return JNI_FALSE;
-        }
-        MTLContext* ctx = mtlsdo->configInfo->context;
-        MTLTextureDescriptor *stencilDataDescriptor =
-                [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatR8Uint
-                                                                   width:texture.width
-                                                                  height:texture.height
-                                                               mipmapped:NO];
-        stencilDataDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
-        stencilDataDescriptor.storageMode = MTLStorageModePrivate;
-        bmtlsdo->pStencilData = [ctx.device newTextureWithDescriptor:stencilDataDescriptor];
-
-        MTLTextureDescriptor *stencilTextureDescriptor =
-                [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatStencil8
-                                                                   width:texture.width
-                                                                  height:texture.height
-                                                               mipmapped:NO];
-        stencilTextureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
-        stencilTextureDescriptor.storageMode = MTLStorageModePrivate;
-        bmtlsdo->pStencilTexture = [ctx.device newTextureWithDescriptor:stencilTextureDescriptor];
-
-        bmtlsdo->isOpaque = isOpaque;
-        bmtlsdo->width = texture.width;
-        bmtlsdo->height = texture.height;
-        bmtlsdo->drawableType = MTLSD_RT_TEXTURE;
-
-        [texture retain];
-
-        J2dTraceLn(J2D_TRACE_VERBOSE, "MTLSurfaceData_initTexture: w=%d h=%d bp=%p [tex=%p] opaque=%d sfType=%d",
-                   bmtlsdo->width, bmtlsdo->height, bmtlsdo, bmtlsdo->pTexture, isOpaque, bmtlsdo->drawableType);
-        return JNI_TRUE;
-    }
-}
-
 /**
  * Initializes an MTL texture, using the given width and height as
  * a guide.
@@ -195,19 +120,6 @@ Java_sun_java2d_metal_MTLSurfaceData_initTexture(
     if (!MTLSurfaceData_initTexture((BMTLSDOps *)pData, isOpaque, MTLSD_TEXTURE, width, height))
         return JNI_FALSE;
     MTLSD_SetNativeDimensions(env, (BMTLSDOps *)pData, width, height);
-    return JNI_TRUE;
-}
-
-JNIEXPORT jboolean JNICALL
-Java_sun_java2d_metal_MTLSurfaceData_initWithTexture(
-        JNIEnv *env, jobject mtlds,
-        jlong pData, jboolean isOpaque,
-        jlong pTexture) {
-    BMTLSDOps *bmtlsdops = (BMTLSDOps *) pData;
-    if (!MTLSurfaceData_initWithTexture(bmtlsdops, isOpaque, jlong_to_ptr(pTexture))) {
-        return JNI_FALSE;
-    }
-    MTLSD_SetNativeDimensions(env, (BMTLSDOps *) pData, bmtlsdops->width, bmtlsdops->height);
     return JNI_TRUE;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceDataExt.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceDataExt.m
@@ -1,0 +1,102 @@
+#import "MTLSurfaceData.h"
+
+#import "jni_util.h"
+
+// From MTLSurfaceData.m
+extern void MTLSD_SetNativeDimensions(JNIEnv *env, BMTLSDOps *bmtlsdo, jint w, jint h);
+
+static jboolean MTLSurfaceData_initWithTexture(
+    BMTLSDOps *bmtlsdo,
+    jboolean isOpaque,
+    void* pTexture
+) {
+    @autoreleasepool {
+        if (bmtlsdo == NULL) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: ops are null");
+            return JNI_FALSE;
+        }
+
+        if (pTexture == NULL) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: texture is null");
+            return JNI_FALSE;
+        }
+
+        id <MTLTexture> texture = (__bridge id <MTLTexture>) pTexture;
+        if (texture == NULL) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: failed to cast texture to MTLTexture");
+            return JNI_FALSE;
+        }
+
+        if (texture.width >= MTL_GPU_FAMILY_MAC_TXT_SIZE || texture.height >= MTL_GPU_FAMILY_MAC_TXT_SIZE ||
+            texture.width == 0 || texture.height == 0) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: wrong texture size %d x %d",
+                          texture.width, texture.height);
+            return JNI_FALSE;
+        }
+
+        if (texture.pixelFormat != MTLPixelFormatBGRA8Unorm) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: unsupported pixel format: %d",
+                          texture.pixelFormat);
+            return JNI_FALSE;
+        }
+
+        bmtlsdo->pTexture = texture;
+        bmtlsdo->pOutTexture = NULL;
+
+        MTLSDOps *mtlsdo = (MTLSDOps *)bmtlsdo->privOps;
+        if (mtlsdo == NULL) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: MTLSDOps are null");
+            return JNI_FALSE;
+        }
+        if (mtlsdo->configInfo == NULL || mtlsdo->configInfo->context == NULL) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLSurfaceData_initWithTexture: MTLSDOps wasn't initialized (context is null)");
+            return JNI_FALSE;
+        }
+        MTLContext* ctx = mtlsdo->configInfo->context;
+        MTLTextureDescriptor *stencilDataDescriptor =
+                [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatR8Uint
+                                                                   width:texture.width
+                                                                  height:texture.height
+                                                               mipmapped:NO];
+        stencilDataDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+        stencilDataDescriptor.storageMode = MTLStorageModePrivate;
+        bmtlsdo->pStencilData = [ctx.device newTextureWithDescriptor:stencilDataDescriptor];
+
+        MTLTextureDescriptor *stencilTextureDescriptor =
+                [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatStencil8
+                                                                   width:texture.width
+                                                                  height:texture.height
+                                                               mipmapped:NO];
+        stencilTextureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
+        stencilTextureDescriptor.storageMode = MTLStorageModePrivate;
+        bmtlsdo->pStencilTexture = [ctx.device newTextureWithDescriptor:stencilTextureDescriptor];
+
+        bmtlsdo->isOpaque = isOpaque;
+        bmtlsdo->width = texture.width;
+        bmtlsdo->height = texture.height;
+        bmtlsdo->drawableType = MTLSD_RT_TEXTURE;
+
+        [texture retain];
+
+        J2dTraceLn(J2D_TRACE_VERBOSE, "MTLSurfaceData_initTexture: w=%d h=%d bp=%p [tex=%p] opaque=%d sfType=%d",
+                   bmtlsdo->width, bmtlsdo->height, bmtlsdo, bmtlsdo->pTexture, isOpaque, bmtlsdo->drawableType);
+        return JNI_TRUE;
+    }
+}
+
+JNIEXPORT jboolean JNICALL
+Java_sun_java2d_metal_MTLSurfaceDataExt_initWithTexture(
+    JNIEnv *env,
+    jclass cls,
+    jlong pData,
+    jboolean isOpaque,
+    jlong pTexture
+) {
+    BMTLSDOps *bmtlsdops = (BMTLSDOps *) pData;
+    if (!MTLSurfaceData_initWithTexture(bmtlsdops, isOpaque, jlong_to_ptr(pTexture))) {
+        return JNI_FALSE;
+    }
+    MTLSD_SetNativeDimensions(env, (BMTLSDOps *) pData, bmtlsdops->width, bmtlsdops->height);
+    return JNI_TRUE;
+}
+

--- a/src/java.desktop/share/classes/com/jetbrains/desktop/SharedTextures.java
+++ b/src/java.desktop/share/classes/com/jetbrains/desktop/SharedTextures.java
@@ -26,52 +26,18 @@
 package com.jetbrains.desktop;
 
 import com.jetbrains.desktop.image.TextureWrapperImage;
-import com.jetbrains.exported.JBRApi;
-import sun.awt.SunToolkit;
+import sun.awt.image.SurfaceManager;
 
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsEnvironment;
-import java.awt.Image;
+import java.awt.*;
 
-@JBRApi.Service
-@JBRApi.Provides("SharedTextures")
-public class SharedTextures {
+public abstract class SharedTextures {
     public final static int METAL_TEXTURE_TYPE = 1;
 
-    private final int textureType;
+    public abstract int getTextureType();
 
-    public static SharedTextures create() {
-        return new SharedTextures();
+    public final Image wrapTexture(GraphicsConfiguration gc, long texture) {
+        return new TextureWrapperImage((img) -> createSurfaceManager(gc, img, texture));
     }
 
-    private SharedTextures() {
-        textureType = getTextureTypeImpl();
-        if (textureType == 0) {
-            throw new JBRApi.ServiceNotAvailableException();
-        }
-    }
-
-    public int getTextureType() {
-        return textureType;
-    }
-
-    public Image wrapTexture(GraphicsConfiguration gc, long texture) {
-        return new TextureWrapperImage(gc, texture);
-    }
-
-    private static int getTextureTypeImpl() {
-        GraphicsConfiguration gc = GraphicsEnvironment
-                .getLocalGraphicsEnvironment()
-                .getDefaultScreenDevice()
-                .getDefaultConfiguration();
-        try {
-            if (SunToolkit.isInstanceOf(gc, "sun.java2d.metal.MTLGraphicsConfig")) {
-                return METAL_TEXTURE_TYPE;
-            }
-        } catch (Exception e) {
-            throw new InternalError("Unexpected exception during reflection", e);
-        }
-
-        return 0;
-    }
+    protected abstract SurfaceManager createSurfaceManager(GraphicsConfiguration gc, Image image, long texture);
 }

--- a/src/java.desktop/share/classes/com/jetbrains/desktop/image/TextureWrapperImage.java
+++ b/src/java.desktop/share/classes/com/jetbrains/desktop/image/TextureWrapperImage.java
@@ -37,6 +37,7 @@ import java.awt.ImageCapabilities;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
+import java.util.function.Function;
 
 /**
  * This class is a wrapper for a GPU texture-based image.
@@ -51,31 +52,14 @@ import java.awt.image.ImageProducer;
  * the surface flushing.
  */
 public class TextureWrapperImage extends Image {
-    final GraphicsConfiguration gc;
     final SurfaceData sd;
     final static ImageCapabilities capabilities = new ImageCapabilities(true);
 
-    /**
-     * Constructs a TextureWrapperImage instance with the specified graphics configuration
-     * and a texture.
-     *
-     * @param gc the graphics configuration
-     * @param texture the texture that will be wrapped by this instance.
-     *                Platform-specific details:
-     *                macOS (with the Metal rendering pipeline) - a pointer to an MTLTexture object is expected
-     *
-     * @throws UnsupportedOperationException if the current pipeline is not supported
-     * @throws IllegalArgumentException if the texture cannot be wrapped
-     */
-    public TextureWrapperImage(GraphicsConfiguration gc, long texture)
+    public TextureWrapperImage(Function<Image, SurfaceManager> surfaceManagerFactory)
             throws UnsupportedOperationException, IllegalArgumentException {
-        this.gc = gc;
-        SurfaceManager surfaceManager;
-        if (gc instanceof SurfaceManager.TextureWrapperFactory factory) {
-            surfaceManager = factory.createTextureWrapperSurfaceManager(gc, this, texture);
-        } else throw new UnsupportedOperationException();
-        sd = surfaceManager.getPrimarySurfaceData();
-        SurfaceManager.setManager(this, surfaceManager);
+        SurfaceManager sm = surfaceManagerFactory.apply(this);
+        sd = sm.getPrimarySurfaceData();
+        SurfaceManager.setManager(this, sm);
     }
 
     @Override

--- a/src/java.desktop/share/classes/com/jetbrains/desktop/image/TextureWrapperSurfaceManager.java
+++ b/src/java.desktop/share/classes/com/jetbrains/desktop/image/TextureWrapperSurfaceManager.java
@@ -23,8 +23,9 @@
  * questions.
  */
 
-package sun.awt.image;
+package com.jetbrains.desktop.image;
 
+import sun.awt.image.SurfaceManager;
 import sun.java2d.SurfaceData;
 
 import java.awt.GraphicsConfiguration;

--- a/src/java.desktop/share/classes/sun/awt/image/SurfaceManager.java
+++ b/src/java.desktop/share/classes/sun/awt/image/SurfaceManager.java
@@ -185,14 +185,6 @@ public abstract class SurfaceManager {
     }
 
     /**
-     * See TextureWrapperImage.
-     */
-    public interface TextureWrapperFactory {
-        SurfaceManager createTextureWrapperSurfaceManager(
-                GraphicsConfiguration gc, Image image, long texture);
-    }
-
-    /**
      * An interface for GraphicsConfiguration objects to implement if
      * they create their own VolatileSurfaceManager implementations.
      */

--- a/test/jdk/jb/SharedTextures/SharedTexturesTest.java
+++ b/test/jdk/jb/SharedTextures/SharedTexturesTest.java
@@ -1,4 +1,5 @@
 import com.jetbrains.desktop.SharedTextures;
+import com.jetbrains.desktop.SharedTexturesService;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -31,8 +32,8 @@ public class SharedTexturesTest {
         BufferedImage originalImage = createImage();
         byte[] bytes = getPixelData(originalImage);
 
-        SharedTextures sharedTexturesService = SharedTextures.create();
-        Asserts.assertEquals(sharedTexturesService.getTextureType(), SharedTextures.METAL_TEXTURE_TYPE);
+        SharedTextures sharedTexturesService = new SharedTexturesService();
+        Asserts.assertEquals(sharedTexturesService.getTextureType(), SharedTexturesService.METAL_TEXTURE_TYPE);
 
         BufferedImage bufferedImageContent;
         BufferedImage volatileImageContent;


### PR DESCRIPTION
- introduce abstract `SharedTextures` class.
- revert affected existing openjdk files and put the code to separate files(where possible) to simplify merging
- get rid of `SurfaceManager.TextureWrapperFactory`
- get rid of reflection