### PR TITLE
JBR-9580 Fix crash in [MenuAccessibility accessibilityChildren]

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
@@ -67,9 +67,17 @@ static jclass sjc_CAccessibility = NULL;
     jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
                                                              sjm_getCurrentAccessiblePopupMenu,
                                                              fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axComponent == NULL) {
+        return nil;
+    }
 
     CommonComponentAccessibility *currentElement = [CommonComponentAccessibility createWithAccessible:axComponent
                                                             withEnv:env withView:self->fView isCurrent:YES];
+    (*env)->DeleteLocalRef(env, axComponent);
+    if (currentElement == nil) {
+        return nil;
+    }
 
     NSArray *children = [CommonComponentAccessibility childrenOfParent:currentElement
                                 withEnv:env


### PR DESCRIPTION
* Add null checks for variables that can have null values to prevent hard crash
* Add missing CHECK_EXCEPTION after JNI call
* Add missing DeleteLocalRef for axComponent