### PR TITLE
JBR-10147 Optimize performace of CAccessibility.getChildrenAndRolesRecursive for JTree

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -31,6 +31,7 @@ import java.awt.Dimension;
 import java.awt.IllegalComponentStateException;
 import java.awt.KeyboardFocusManager;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
@@ -69,6 +70,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
+import javax.swing.tree.TreePath;
 
 import sun.awt.AWTAccessor;
 import sun.lwawt.LWWindowPeer;
@@ -765,6 +767,46 @@ class CAccessibility implements PropertyChangeListener {
         return invokeAndWait(new Callable<Object[]>() {
             public Object[] call() throws Exception {
                 ArrayList<Object> allChildren = new ArrayList<Object>();
+                Accessible at;
+                if (a instanceof CAccessible) {
+                    at = CAccessible.getSwingAccessible(a);
+                } else {
+                    at = a;
+                }
+
+                if (at instanceof JTree tree && tree.getAccessibleContext() instanceof AccessibleComponent aComp) {
+                    TreePath[] paths = null;
+                    if (whichChildren == JAVA_AX_ALL_CHILDREN || whichChildren == JAVA_AX_VISIBLE_CHILDREN) {
+                        int count = tree.getRowCount();
+                        paths = new TreePath[count];
+                        for (int i = 0; i < count; i++) {
+                            paths[i] = tree.getPathForRow(i);
+                        }
+                    } else if (whichChildren == JAVA_AX_SELECTED_CHILDREN) {
+                        paths = tree.getSelectionPaths();
+                    }
+                    if (paths != null) {
+                        for (TreePath path : paths) {
+                            Rectangle bounds = tree.getPathBounds(path);
+                            if (bounds == null) continue;
+
+                            Accessible node = aComp.getAccessibleAt(new Point(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2));
+                            if (node == null) continue;
+
+                            AccessibleContext ac = node.getAccessibleContext();
+                            if (ac == null) continue;
+
+                            if (whichChildren == JAVA_AX_VISIBLE_CHILDREN && !ac.getAccessibleStateSet().contains(AccessibleState.VISIBLE))
+                                continue;
+
+                            allChildren.add(node);
+                            allChildren.add(ac.getAccessibleRole());
+                            allChildren.add(String.valueOf(tree.isRootVisible() ? path.getPathCount() - 1 : path.getPathCount() - 2));
+                        }
+                        return allChildren.toArray();
+                    }
+                }
+
                 ArrayList<Object> currentLevelChildren = new ArrayList<Object>();
                 ArrayList<Accessible> parentStack = new ArrayList<Accessible>();
                 HashMap<Accessible, List<Object>> childrenOfParent = new HashMap<>();
@@ -805,9 +847,9 @@ class CAccessibility implements PropertyChangeListener {
                         continue;
                     }
 
-                    if ((cac.getAccessibleStateSet().contains(AccessibleState.SELECTED) && (whichChildren == JAVA_AX_SELECTED_CHILDREN)) ||
-                            (cac.getAccessibleStateSet().contains(AccessibleState.VISIBLE) && (whichChildren == JAVA_AX_VISIBLE_CHILDREN)) ||
-                            (whichChildren == JAVA_AX_ALL_CHILDREN)) {
+                    if ((whichChildren == JAVA_AX_SELECTED_CHILDREN && cac.getAccessibleStateSet().contains(AccessibleState.SELECTED)) ||
+                            (whichChildren == JAVA_AX_VISIBLE_CHILDREN && cac.getAccessibleStateSet().contains(AccessibleState.VISIBLE)) ||
+                            whichChildren == JAVA_AX_ALL_CHILDREN) {
                         allChildren.add(ca);
                         allChildren.add(role);
                         allChildren.add(String.valueOf(currentLevel));

--- a/test/jdk/java/awt/a11y/AccessibleJTreeVoiceOverFreezeTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTreeVoiceOverFreezeTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.awt.Dimension;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/*
+ * @test
+ * @summary JBR-10147 Test for freezes when VoiceOver interacts with large trees
+ * @author dmitry.drobotov@jetbrains.com
+ * @requires (os.family == "mac")
+ * @run main/manual AccessibleJTreeVoiceOverFreezeTest
+ */
+
+public class AccessibleJTreeVoiceOverFreezeTest extends AccessibleComponentTest {
+    private static final int NODE_COUNT = 100_000;
+    private static final int LEVELS = 10;
+    private static final int FREEZE_TIMEOUT_SECONDS = 10;
+
+    @Override
+    public CountDownLatch createCountDownLatch() {
+        return new CountDownLatch(1);
+    }
+
+    private void createTree() {
+        INSTRUCTIONS = """
+                INSTRUCTIONS:
+                Check that there is no freeze while navigating a large JTree with VoiceOver enabled.
+
+                Turn VoiceOver on (Cmd + F5).
+                Tab to the tree.
+                Move the selection using Up/Down arrows multiple times.
+
+                The test will automatically fail if the EDT is unresponsive for 10 seconds.
+                A short freeze is acceptable on the first focus of the tree.
+                If the UI doesn't freeze, press PASS.
+                If you notice a freeze that was not detected automatically, press FAIL.""";
+
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode("Root");
+        DefaultMutableTreeNode current = root;
+        for (int level = 1; level <= LEVELS; level++) {
+            for (int i = 1; i <= NODE_COUNT / LEVELS; i++) {
+                current.add(new DefaultMutableTreeNode("Level" + level + " Node" + i));
+            }
+            current = (DefaultMutableTreeNode) current.getFirstChild();
+        }
+
+        JTree tree = new JTree(root);
+        tree.setRootVisible(true);
+        for (int i = 0; i < tree.getRowCount(); i++) {
+            tree.expandRow(i);
+        }
+
+        JScrollPane scrollPane = new JScrollPane(tree);
+        scrollPane.setPreferredSize(new Dimension(400, 600));
+
+        JPanel panel = new JPanel();
+        panel.add(scrollPane);
+
+        exceptionString = "AccessibleJTreeVoiceOverFreezeTest test failed!";
+        super.createUI(panel, "AccessibleJTreeVoiceOverFreezeTest");
+    }
+
+    public static void main(String[] args) throws Exception {
+        AccessibleJTreeVoiceOverFreezeTest test = new AccessibleJTreeVoiceOverFreezeTest();
+
+        countDownLatch = test.createCountDownLatch();
+        SwingUtilities.invokeLater(test::createTree);
+
+        Thread freezeMonitor = new Thread(() -> {
+            while (countDownLatch.getCount() > 0) {
+                CountDownLatch ping = new CountDownLatch(1);
+                SwingUtilities.invokeLater(ping::countDown);
+                try {
+                    if (!ping.await(FREEZE_TIMEOUT_SECONDS, TimeUnit.SECONDS) && countDownLatch.getCount() > 0) {
+                        testResult = false;
+                        countDownLatch.countDown();
+                        return;
+                    }
+                    //noinspection BusyWait
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        }, "freeze-monitor");
+        freezeMonitor.setDaemon(true);
+        freezeMonitor.start();
+
+        //noinspection ResultOfMethodCallIgnored
+        countDownLatch.await(15, TimeUnit.MINUTES);
+
+        if (!testResult) {
+            throw new RuntimeException(exceptionString);
+        }
+    }
+}


### PR DESCRIPTION
This PR speeds up the `CAccessibility.getChildrenAndRolesRecursive` method for JTrees.
From my testing, it may be called in the following cases:
* With `JAVA_AX_ALL_CHILDREN` when VoiceOver or Full Keyboard Access are enabled and interacting with a tree, usually on only the first focus
* With `JAVA_AX_SELECTED_CHILDREN` when one of interactive assistive tools or settings is enabled, such as VoiceOver, Zoom, VoiceControl, Hover Text, etc. It's called on focus of the tree and on every selection change. Also, for me when all known assistive tools were turned off, it was sometimes called on mouse clicks on nodes, on tree focus, and node expansion - it could be coming from a non-accessibility related OS tool or setting, or from a third-party app that uses accessibility APIs.
* With `JAVA_AX_VISIBLE_CHILDREN` when Voice Control was enabled and listening.

The approach is based on https://github.com/JetBrains/JetBrainsRuntime/commit/ffa33d7b807bfef6ff05c9adba869dddf813cf68 with the following changes:

* Instead of using reflection to obtain `AccessibleJTreeNode` from `TreePath` (which had issues described in https://bugs.openjdk.org/browse/JDK-8329667?focusedId=14668819&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14668819), I used `getPathBounds` and `getAccessibleAt`.
* Decreased the level of nodes by 1: from `allChildren.add(String.valueOf((tree.isRootVisible() ? path.getPathCount() : path.getPathCount() - 1)));` to `allChildren.add(String.valueOf(tree.isRootVisible() ? path.getPathCount() - 1 : path.getPathCount() - 2));`. This way it matches the level from the code path below. For example, if the root is visible and the path is [Root], its level should be 0 (== count - 1), for path is [Root, Node1] the level needs to be 1 and so on. If root is not visible, it's still included in the path, so levels are decreased by 2 from the count.
* Used the same code for `JAVA_AX_VISIBLE_CHILDREN` because it's used by Voice Control.

The main improvement between the existing code is with `JAVA_AX_SELECTED_CHILDREN` argument. Previously, the code was iterating the whole tree to find selected nodes, now it gets them instantly. For `JAVA_AX_ALL_CHILDREN` and `JAVA_AX_VISIBLE_CHILDREN` there is also an improvement because we avoid a lot of `clear`, `add`, `addAll` operations with arrays. From my basic benchmark on 50k nodes tree, for `JAVA_AX_SELECTED_CHILDREN` the time went from 6s to <1ms, for `JAVA_AX_ALL_CHILDREN` from 6s to 1.5s and for  `JAVA_AX_VISIBLE_CHILDREN` from 6s to 2s. If we still get reports of freezes after this fix, we can try adding a limit (e.g., 1000) to the the returned children count, but for now I think this is already a good improvement.

The `allowIgnored` argument is not handled because for trees (NSAccessibilityOutlineRole) it's always passed as true: https://github.com/JetBrains/JetBrainsRuntime/blob/jbr25/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m#L686

Another change is flipping the order of comparison of accessible states in the code path below (for non-JTrees). `cac.getAccessibleStateSet()` can be expensive and this way we skip it if `whichChildren == JAVA_AX_ALL_CHILDREN`.


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
