### PR TITLE
JBR-10154 Allow specifying macOS SDK as `SYSROOT` env variable

### DIFF
--- a/jb/project/tools/mac/scripts/mkimages.sh
+++ b/jb/project/tools/mac/scripts/mkimages.sh
@@ -44,6 +44,12 @@ else
   fi
 fi
 
+if [ -n "${SYSROOT:-}" ]; then
+  WITH_SYSROOT="--with-sysroot=$SYSROOT"
+else
+  WITH_SYSROOT=""
+fi
+
 function do_configure {
   sh configure \
     $WITH_DEBUG_LEVEL \
@@ -62,6 +68,7 @@ function do_configure {
     $REPRODUCIBLE_BUILD_OPTS \
     $WITH_ZIPPED_NATIVE_DEBUG_SYMBOLS \
     $WITH_XCODE_PATH \
+    $WITH_SYSROOT \
     || do_exit $?
 }
 


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
