### PR TITLE
JBR-9859: Catch NSException during display reconfiguration in AWTWindow / CGraphicsEnv

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1063,23 +1063,30 @@ AWT_ASSERT_APPKIT_THREAD;
         NSLog(@"WARNING: suppressed exception from ConvertNSScreenRect() in [AWTWindow _deliverMoveResizeEvent]");
         NSProcessInfo *processInfo = [NSProcessInfo processInfo];
         [NSApplicationAWT logException:e forProcess:processInfo];
+        (*env)->DeleteLocalRef(env, platformWindow);
         return;
     }
 
-    GET_CPLATFORM_WINDOW_CLASS();
-    DECLARE_METHOD(jm_deliverMoveResizeEvent, jc_CPlatformWindow, "deliverMoveResizeEvent", "(IIIIZ)V");
-    (*env)->CallVoidMethod(env, platformWindow, jm_deliverMoveResizeEvent,
-                      (jint)frame.origin.x,
-                      (jint)frame.origin.y,
-                      (jint)frame.size.width,
-                      (jint)frame.size.height,
-                      (jboolean)[self.nsWindow inLiveResize]);
-    CHECK_EXCEPTION();
-    (*env)->DeleteLocalRef(env, platformWindow);
+    @try {
+        GET_CPLATFORM_WINDOW_CLASS();
+        DECLARE_METHOD(jm_deliverMoveResizeEvent, jc_CPlatformWindow, "deliverMoveResizeEvent", "(IIIIZ)V");
+        (*env)->CallVoidMethod(env, platformWindow, jm_deliverMoveResizeEvent,
+                          (jint)frame.origin.x,
+                          (jint)frame.origin.y,
+                          (jint)frame.size.width,
+                          (jint)frame.size.height,
+                          (jboolean)[self.nsWindow inLiveResize]);
+        CHECK_EXCEPTION();
+        (*env)->DeleteLocalRef(env, platformWindow);
 
-    [AWTWindow synthesizeMouseEnteredExitedEventsForAllWindows];
+        [AWTWindow synthesizeMouseEnteredExitedEventsForAllWindows];
 
-    [self updateFullScreenButtons];
+        [self updateFullScreenButtons];
+    } @catch (NSException *e) {
+        NSLog(@"WARNING: suppressed NSException from [AWTWindow _deliverMoveResizeEvent] post-JNI: %@", e);
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        [NSApplicationAWT logException:e forProcess:processInfo];
+    }
 }
 
 - (void)windowDidMove:(NSNotification *)notification {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
@@ -161,6 +161,8 @@ JNI_COCOA_ENTER(env);
                 (*env)->CallVoidMethod(env, graphicsEnv, jm_displayReconfigurationFinished);
                 (*env)->DeleteLocalRef(env, graphicsEnv);
                 CHECK_EXCEPTION();
+            } @catch (NSException *e) {
+                NSLog(@"WARNING: suppressed NSException in CGraphicsEnv displayReconfigure callback: %@", e);
             } @finally {
                 // Allow LWCToolkit.invokeAndWait() once Finished callbacks:
                 [ThreadUtilities setBlockingMainThread:false];
@@ -173,15 +175,19 @@ JNI_COCOA_ENTER(env);
 
     // braces to reduce variable scope
     {
-        jobject graphicsEnv = (*env)->NewLocalRef(env, cgeRef);
-        if (graphicsEnv == NULL) return; // ref already GC'd
-        DECLARE_CLASS(jc_CGraphicsEnvironment, "sun/awt/CGraphicsEnvironment");
-        DECLARE_METHOD(jm_displayReconfiguration,
-                jc_CGraphicsEnvironment, "_displayReconfiguration","(II)V");
-        (*env)->CallVoidMethod(env, graphicsEnv, jm_displayReconfiguration,
-                               (jint) displayId, (jint) flags);
-        (*env)->DeleteLocalRef(env, graphicsEnv);
-        CHECK_EXCEPTION();
+        @try {
+            jobject graphicsEnv = (*env)->NewLocalRef(env, cgeRef);
+            if (graphicsEnv == NULL) return; // ref already GC'd
+            DECLARE_CLASS(jc_CGraphicsEnvironment, "sun/awt/CGraphicsEnvironment");
+            DECLARE_METHOD(jm_displayReconfiguration,
+                    jc_CGraphicsEnvironment, "_displayReconfiguration","(II)V");
+            (*env)->CallVoidMethod(env, graphicsEnv, jm_displayReconfiguration,
+                                   (jint) displayId, (jint) flags);
+            (*env)->DeleteLocalRef(env, graphicsEnv);
+            CHECK_EXCEPTION();
+        } @catch (NSException *e) {
+            NSLog(@"WARNING: suppressed NSException in CGraphicsEnv displayReconfiguration: %@", e);
+        }
     }
 JNI_COCOA_EXIT(env);
 }


### PR DESCRIPTION
## Summary

Wraps two unguarded NSException-prone sites so AppKit exceptions raised during display reconfiguration / sleep-wake stop terminating the IDE.

Fixes JBR-9859 (umbrella, Critical) and dups: JBR-9927, JBR-9995, JBR-10022, JBR-10082, JBR-10086, JBR-8651, IDEA-385525, IDEA-385958, PY-86947, DBE-25474, CPP-48928.

## Root cause

On wake / display reconfigure, AppKit drives the AWT observer chain synchronously. Two native sites let NSException propagate out:

- **`AWTWindow.m -[AWTWindow _deliverMoveResizeEvent]`** — only `ConvertNSScreenRect` is guarded. The JNI `deliverMoveResizeEvent` call and the post-JNI `synthesizeMouseEnteredExitedEventsForAllWindows` / `updateFullScreenButtons` (both touch AppKit state) are unguarded. Matches @bourgesl's "Last Exception Backtrace" finding (`_deliverMoveResizeEvent + 988`).
- **`CGraphicsEnv.m displaycb_handle`** — runloop block uses `@try/@finally` (no `@catch`); outer `_displayReconfiguration` JNI call has no `@try`.

Either path → uncaught NSException → `std::terminate` → SIGABRT. Terminal frame is `_NSApplicationReactToScreenInvalidation` or `__displaycb_handle_block_invoke` depending on timing.

## Fix

`AWTWindow.m _deliverMoveResizeEvent`: wrap post-`ConvertNSScreenRect` body in `@try/@catch (NSException *)`, log via `[NSApplicationAWT logException:forProcess:]`. Release `platformWindow` local ref on the existing catch-path early return.

`CGraphicsEnv.m displaycb_handle`: add `@catch (NSException *)` to the registered runloop block (preserves `@finally setBlockingMainThread:false`); wrap outer `_displayReconfiguration` JNI call in `@try/@catch`.

Strictly additive — no handler removed, success path unchanged.

## Reproduction

Apple Silicon M4 (Mac16,5), macOS 15.7.3, IntelliJ IDEA 2025.1, JBR 21.0.7+9 and engineering 21.0.10+7-b1163.113. Wake-from-sleep with multi-monitor or hot-plug. Crash logs attached on JBR-9859.


