### PR TITLE
JBR-9098 AppCDS writes local paths into .jsa archive: Fix slow class loading of relocated app with AppCDS/AOT

### DIFF
--- a/src/hotspot/share/cds/aotClassLocation.cpp
+++ b/src/hotspot/share/cds/aotClassLocation.cpp
@@ -51,6 +51,8 @@
 Array<ClassPathZipEntry*>* AOTClassLocationConfig::_dumptime_jar_files = nullptr;
 AOTClassLocationConfig* AOTClassLocationConfig::_dumptime_instance = nullptr;
 const AOTClassLocationConfig* AOTClassLocationConfig::_runtime_instance = nullptr;
+const char* AOTClassLocationConfig::_runtime_lcp = nullptr;
+size_t AOTClassLocationConfig::_runtime_lcp_len = 0;
 
 // A ClassLocationStream represents a list of code locations, which can be iterated using
 // start() and has_next().
@@ -650,6 +652,32 @@ AOTClassLocation const* AOTClassLocationConfig::class_location_at(int index) con
   return _class_locations->at(index);
 }
 
+void AOTClassLocationConfig::set_runtime_lcp(const char* lcp, size_t lcp_len) {
+  if (_runtime_lcp != nullptr) {
+    os::free((void*)_runtime_lcp);
+    _runtime_lcp = nullptr;
+    _runtime_lcp_len = 0;
+  }
+  if (lcp != nullptr && lcp_len > 0) {
+    _runtime_lcp = os::strdup(lcp, mtClassShared);
+    _runtime_lcp_len = lcp_len;
+  }
+}
+
+const char* AOTClassLocationConfig::runtime_path(int index) const {
+  const char* path = class_location_at(index)->path();
+  if (_runtime_lcp != nullptr && _dumptime_lcp_len > 0 &&
+      index >= boot_cp_start_index() && index < app_cp_end_index() &&
+      strlen(path) > _dumptime_lcp_len) {
+    // validate() accepted this archive by substituting the longest common prefix of the
+    // dump-time paths with the (different) runtime prefix -- see check_classpaths().
+    // Apply the same substitution here, so that callers get the path where the file
+    // actually lives at runtime, not the (possibly stale) dump-time path.
+    return substitute(path, _dumptime_lcp_len, _runtime_lcp, _runtime_lcp_len);
+  }
+  return path;
+}
+
 int AOTClassLocationConfig::get_module_shared_path_index(Symbol* location) const {
   if (location->starts_with("jrt:", 4)) {
     assert(class_location_at(0)->is_modules_image(), "sanity");
@@ -968,6 +996,8 @@ bool AOTClassLocationConfig::need_lcp_match_helper(int start, int end, ClassLoca
 bool AOTClassLocationConfig::validate(const char* cache_filename, bool has_aot_linked_classes, bool* has_extra_module_paths) const {
   ResourceMark rm;
   AllClassLocationStreams all_css;
+  const char* used_lcp = nullptr; // runtime LCP if this archive is accepted via LCP substitution
+  size_t used_lcp_len = 0;
 
   log_locations(cache_filename, /*is_write=*/false);
 
@@ -1014,6 +1044,18 @@ bool AOTClassLocationConfig::validate(const char* cache_filename, bool has_aot_l
                                    all_css.module_path(), has_extra_module_paths);
       log_info(class, path)("Archived module path validation: %s%s", success ? "passed" : "failed",
                             (*has_extra_module_paths) ? " (extra module paths found)" : "");
+    }
+
+    if (success && use_lcp_match && runtime_lcp_len > 0 && _dumptime_lcp_len > 0) {
+      used_lcp = runtime_lcp; // still owned by runtime_lcp; strdup'ed by set_runtime_lcp() below
+      used_lcp_len = runtime_lcp_len;
+    }
+
+    if (success) {
+      // Remember the substitution (or clear a previously remembered one), so that
+      // runtime_path() can return the actual runtime locations of the archived
+      // classpath entries.
+      set_runtime_lcp(used_lcp, used_lcp_len);
     }
 
     if (runtime_lcp_len > 0) {

--- a/src/hotspot/share/cds/aotClassLocation.hpp
+++ b/src/hotspot/share/cds/aotClassLocation.hpp
@@ -140,6 +140,14 @@ class AOTClassLocationConfig : public CHeapObj<mtClassShared> {
   static AOTClassLocationConfig* _dumptime_instance;
   static const AOTClassLocationConfig* _runtime_instance;
 
+  // If validate() accepted the archive using longest-common-prefix (LCP) substitution
+  // (i.e., the application has been moved to a different directory since the archive
+  // was created), these record the runtime LCP that replaces the first _dumptime_lcp_len
+  // characters of each archived boot/app classpath entry. Otherwise _runtime_lcp is null.
+  static const char* _runtime_lcp;
+  static size_t _runtime_lcp_len;
+  static void set_runtime_lcp(const char* lcp, size_t lcp_len);
+
   Array<AOTClassLocation*>* _class_locations; // jrt -> -Xbootclasspath/a -> -classpath -> --module_path
   static Array<ClassPathZipEntry*>* _dumptime_jar_files;
 
@@ -236,6 +244,13 @@ public:
 
   const AOTClassLocation* class_location_at(int index) const;
   int get_module_shared_path_index(Symbol* location) const;
+
+  // Returns the runtime location of the boot/app classpath entry at the given index:
+  // the dump-time path with the LCP substitution applied, if validate() accepted this
+  // archive using LCP substitution (see check_classpaths()). The returned string may be
+  // resource-allocated. Use this (instead of class_location_at(index)->path()) whenever
+  // the returned path is used to access the file system at runtime.
+  const char* runtime_path(int index) const;
 
   // Functions used only during dumptime
   static void dumptime_init(JavaThread* current);

--- a/src/hotspot/share/cds/cdsProtectionDomain.cpp
+++ b/src/hotspot/share/cds/cdsProtectionDomain.cpp
@@ -38,11 +38,13 @@
 #include "memory/universe.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/symbol.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/javaCalls.hpp"
 
 OopHandle CDSProtectionDomain::_shared_protection_domains;
 OopHandle CDSProtectionDomain::_shared_jar_urls;
 OopHandle CDSProtectionDomain::_shared_jar_manifests;
+bool* CDSProtectionDomain::_shared_jar_url_computed = nullptr;
 
 // Initializes the java.lang.Package and java.security.ProtectionDomain objects associated with
 // the given InstanceKlass.
@@ -197,14 +199,21 @@ Handle CDSProtectionDomain::get_shared_jar_manifest(int shared_path_index, TRAPS
 
 Handle CDSProtectionDomain::get_shared_jar_url(int shared_path_index, TRAPS) {
   Handle url_h;
-  if (shared_jar_url(shared_path_index) == nullptr) {
-    const char* path = AOTClassLocationConfig::runtime()->class_location_at(shared_path_index)->path();
+  if (shared_jar_url(shared_path_index) == nullptr &&
+      !Atomic::load_acquire(&_shared_jar_url_computed[shared_path_index])) {
+    ResourceMark rm(THREAD);
+    const char* path = AOTClassLocationConfig::runtime()->runtime_path(shared_path_index);
     oop result_oop = to_file_URL(path, url_h, CHECK_(url_h));
     atomic_set_shared_jar_url(shared_path_index, result_oop);
+    // Remember that the conversion has been attempted. to_file_URL() returns null if
+    // the file does not exist; without this flag, the failing file-system walk in
+    // Path.toRealPath() would be repeated for every class loaded from this location
+    // (benign race: concurrent threads may attempt the conversion more than once).
+    Atomic::release_store(&_shared_jar_url_computed[shared_path_index], true);
   }
 
+  // May be null if the classpath location no longer exists.
   url_h = Handle(THREAD, shared_jar_url(shared_path_index));
-  assert(url_h.not_null(), "sanity");
   return url_h;
 }
 
@@ -331,6 +340,10 @@ void CDSProtectionDomain::allocate_shared_jar_url_array(int size, TRAPS) {
     oop sju = oopFactory::new_objArray(
         vmClasses::URL_klass(), size, CHECK);
     _shared_jar_urls = OopHandle(Universe::vm_global(), sju);
+  }
+  if (_shared_jar_url_computed == nullptr) {
+    _shared_jar_url_computed = NEW_C_HEAP_ARRAY(bool, size, mtClassShared);
+    memset(_shared_jar_url_computed, 0, sizeof(bool) * size);
   }
 }
 

--- a/src/hotspot/share/cds/cdsProtectionDomain.hpp
+++ b/src/hotspot/share/cds/cdsProtectionDomain.hpp
@@ -41,6 +41,12 @@ class CDSProtectionDomain : AllStatic {
   static OopHandle _shared_protection_domains;
   static OopHandle _shared_jar_urls;
   static OopHandle _shared_jar_manifests;
+  // _shared_jar_url_computed[i] is true if we have already attempted to compute
+  // _shared_jar_urls[i]. The attempt can fail (leaving _shared_jar_urls[i] == null)
+  // if the classpath location no longer exists. This flag prevents us from repeating
+  // the (expensive, especially on Windows) failing file-system lookup for every
+  // class loaded from that location.
+  static bool* _shared_jar_url_computed;
 
 public:
   // Package handling:

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2101,8 +2101,10 @@ ClassPathEntry* FileMapInfo::get_classpath_entry_for_jvmti(int i, TRAPS) {
   }
   ClassPathEntry* ent = _classpath_entries_for_jvmti[i];
   if (ent == nullptr) {
-    const AOTClassLocation* cl = AOTClassLocationConfig::runtime()->class_location_at(i);
-    const char* path = cl->path();
+    ResourceMark rm(THREAD);
+    // Use runtime_path() so that this works when the application has been moved
+    // (and the archive was accepted via LCP substitution).
+    const char* path = AOTClassLocationConfig::runtime()->runtime_path(i);
     struct stat st;
     if (os::stat(path, &st) != 0) {
       char *msg = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, char, strlen(path) + 128);


### PR DESCRIPTION
This PR addresses the main problem reported in [JBR-9098 AppCDS writes local paths into .jsa archive](https://youtrack.jetbrains.com/issue/JBR-9098), namely the slowdown in application startup.

The PR is the result of an investigation by myself, following a session with Claude Code Opus 4.8, which verified the problem and produced a fix. I verified that the fix works (the slowdown is gone), but other than that I can't vouch for the code.

Below is a write-up by Claude:

---

## Symptom

With an AppCDS (`.jsa`) or AOT cache created from an absolute classpath, moving the application directory and launching from the new location loses all of the archive's startup benefit — startup becomes *slower than running with no archive at all* (on Windows, ~866 ms vs ~390 ms baseline for a 2,000-class app; the never-moved case is ~183 ms). All classes still load from the archive; the time is spread evenly across every class load. A secondary, cross-platform symptom: archived classes in a relocated app get a `null` `CodeSource`.

## Root cause

`CDSProtectionDomain::get_shared_jar_url()` uses `null` as its "not yet computed" sentinel and builds the URL from the raw *dump-time* classpath path. When the app has moved, that path no longer exists, so `ClassLoaders.toFileURL()` returns `null` after a full `Path.toRealPath()` canonicalization walk of the dead path — and because `null` is never cached, the walk is repeated for **every class loaded from that entry**. On Windows each walk is `FindFirstFile` per path component through the filter-driver stack (~30 metadata syscalls/class here), which is what makes it dominate startup; on macOS/Linux the same repeated walk is far cheaper and effectively invisible.

Separately, `AOTClassLocationConfig::validate()` already detects the relocation and accepts the archive via longest-common-prefix substitution — but then **discards** the substituted (live) path, so class loading still uses the stale one.

## Solution

1. **Reuse the LCP substitution at runtime.** Persist the accepted runtime LCP in `validate()` and add `AOTClassLocationConfig::runtime_path(index)`, which returns the dump-time path with the substitution applied — i.e. where the entry actually lives now. Consume it in `get_shared_jar_url()` and the JVMTI classfile-stream path. This resolves successfully for a moved app, so the URL is computed once and cached, and `CodeSource` is correct again.
2. **Cache negative results.** Add a per-entry `_shared_jar_url_computed[]` flag so the `toFileURL` upcall runs at most once per classpath entry even when it returns `null` (covers cases LCP can't fix, e.g. a relative dump-time path resolved against a different runtime CWD). The now-expected `null` return is documented; the debug-only `assert(url_h.not_null())` is removed.

Relocated-app startup returns to the never-moved figure (866→183 ms jsa, 608→100 ms aot), metadata syscalls drop from ~61k to ~1.1k, and no non-moved scenario regresses. The bug reproduces on stock OpenJDK 25, so this is not JBR-specific.

---------
- [ ] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
