### PR TITLE
Add support for setting WS_EX_NOREDIRECTIONBITMAP on a new AWT window

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WWindowPeer.java
@@ -88,6 +88,9 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
 
     public static final String WINDOW_CORNER_RADIUS = "apple.awt.windowCornerRadius";
 
+    // RootPane client property for setting WS_EX_NOREDIRECTIONBITMAP on the native window
+    public static final String WINDOW_NO_REDIRECTION_BITMAP = "jbr.window.noRedirectionBitmap";
+
     // we can't use WDialogPeer as blocker may be an instance of WPrintDialogPeer that
     // extends WWindowPeer, not WDialogPeer
     private WWindowPeer modalBlocker = null;
@@ -259,22 +262,32 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
             setOpaque(((Window)target).isOpaque());
         }
 
-        if (target instanceof RootPaneContainer) {
-            JRootPane rootpane = ((RootPaneContainer)target).getRootPane();
-            if (rootpane != null) {
-                setRoundedCornersImpl(rootpane.getClientProperty(WINDOW_CORNER_RADIUS));
-            }
+        setRoundedCornersImpl(getRootPaneClientProperty(WINDOW_CORNER_RADIUS));
+    }
+
+    private Object getRootPaneClientProperty(String name) {
+        if (!(target instanceof RootPaneContainer)) {
+            return null;
         }
+        JRootPane rootPane = ((RootPaneContainer)target).getRootPane();
+        if (rootPane == null) {
+            return null;
+        }
+
+        return rootPane.getClientProperty(name);
     }
 
     native void createAwtWindow(WComponentPeer parent);
 
     private volatile Window.Type windowType = Window.Type.NORMAL;
 
+    private volatile boolean noRedirectionBitmap = false;
+
     // This method must be called for Window, Dialog, and Frame before creating
     // the hwnd
     void preCreate(WComponentPeer parent) {
         windowType = ((Window)target).getType();
+        noRedirectionBitmap = Boolean.TRUE.equals(getRootPaneClientProperty(WINDOW_NO_REDIRECTION_BITMAP));
     }
 
     @Override

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -171,6 +171,7 @@ jfieldID AwtWindow::customTitleBarHitTestID;
 jfieldID AwtWindow::customTitleBarHitTestQueryID;
 
 jfieldID AwtWindow::windowTypeID;
+jfieldID AwtWindow::noRedirectionBitmapID;
 jmethodID AwtWindow::notifyWindowStateChangedMID;
 jfieldID AwtWindow::sysInsetsID;
 
@@ -418,6 +419,10 @@ LRESULT CALLBACK AwtWindow::CBTFilter(int nCode, WPARAM wParam, LPARAM lParam)
     return ::CallNextHookEx(AwtWindow::ms_hCBTFilter, nCode, wParam, lParam);
 }
 
+#ifndef WS_EX_NOREDIRECTIONBITMAP
+#define WS_EX_NOREDIRECTIONBITMAP 0x00200000L
+#endif
+
 void AwtWindow::CreateHWnd(JNIEnv *env, LPCWSTR title,
         DWORD windowStyle,
         DWORD windowExStyle,
@@ -431,6 +436,10 @@ void AwtWindow::CreateHWnd(JNIEnv *env, LPCWSTR title,
     JNU_CHECK_EXCEPTION(env);
 
     TweakStyle(windowStyle, windowExStyle);
+
+    if (env->GetBooleanField(peer, AwtWindow::noRedirectionBitmapID)) {
+        windowExStyle |= WS_EX_NOREDIRECTIONBITMAP;
+    }
 
     AwtCanvas::CreateHWnd(env, title,
             windowStyle,
@@ -3032,6 +3041,9 @@ Java_sun_awt_windows_WWindowPeer_initIDs(JNIEnv *env, jclass cls)
 
     AwtWindow::windowTypeID = env->GetFieldID(cls, "windowType",
             "Ljava/awt/Window$Type;");
+
+    CHECK_NULL(AwtWindow::noRedirectionBitmapID =
+        env->GetFieldID(cls, "noRedirectionBitmap", "Z"));
 
     AwtWindow::notifyWindowStateChangedMID =
         env->GetMethodID(cls, "notifyWindowStateChanged", "(II)V");

--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.h
@@ -58,6 +58,7 @@ public:
 
     /* sun.awt.windows.WWindowPeer field and method IDs */
     static jfieldID windowTypeID;
+    static jfieldID noRedirectionBitmapID;
     static jmethodID notifyWindowStateChangedMID;
 
     /* java.awt.Window method IDs */


### PR DESCRIPTION
This PR adds a RootPane client property, `jbr.window.noRedirectionBitmap`, which sets the `WS_EX_NOREDIRECTIONBITMAP` flag on the window (in Windows).

This allows Skiko/Compose to overlay its own content such that window resizing is smooth (no white bars, no jumps).

https://github.com/user-attachments/assets/7d898412-39e6-4e8d-98a4-48ce4d0f4305



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
