### PR TITLE
JBR-10542 Implement `apple.awt.windowSurfaceDisabled` client property

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
@@ -53,13 +53,12 @@ public class MTLLayer extends CFLayer {
     private final boolean perfCountersEnabled;
 
     public MTLLayer(LWWindowPeer peer) {
-        super(0, true);
+        super(0, true, peer);
 
         Window target = (peer != null) ? peer.getTarget() : null;
         this.perfCountersEnabled = (target != null) && AWTAccessor.getWindowAccessor().countersEnabled(target);
 
         setPtr(nativeCreateLayer(perfCountersEnabled));
-        this.peer = peer;
 
         MTLGraphicsConfig gc = (MTLGraphicsConfig)getGraphicsConfiguration();
         if (logger.isLoggable(PlatformLogger.Level.FINE)) {
@@ -71,7 +70,7 @@ public class MTLLayer extends CFLayer {
     }
 
     public SurfaceData replaceSurfaceData(int scale) {
-        if (getBounds().isEmpty()) {
+        if (getBounds().isEmpty() || isWindowSurfaceDisabled()) {
             surfaceData = NullSurfaceData.theInstance;
             return surfaceData;
         }

--- a/src/java.desktop/macosx/classes/sun/java2d/opengl/CGLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/opengl/CGLLayer.java
@@ -43,10 +43,9 @@ public class CGLLayer extends CFLayer {
     private int scale = 1;
 
     public CGLLayer(LWWindowPeer peer) {
-        super(0, true);
+        super(0, true, peer);
 
         setPtr(nativeCreateLayer());
-        this.peer = peer;
 
         CGraphicsConfig gc = (CGraphicsConfig)getGraphicsConfiguration();
         if (logger.isLoggable(PlatformLogger.Level.FINE)) {
@@ -58,7 +57,7 @@ public class CGLLayer extends CFLayer {
     }
 
     public SurfaceData replaceSurfaceData(int scale) {
-        if (getBounds().isEmpty()) {
+        if (getBounds().isEmpty() || isWindowSurfaceDisabled()) {
             surfaceData = NullSurfaceData.theInstance;
             return surfaceData;
         }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFLayer.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CFLayer.java
@@ -30,17 +30,25 @@ import sun.java2d.SurfaceData;
 import java.awt.GraphicsConfiguration;
 import java.awt.Rectangle;
 import java.awt.Transparency;
+import java.awt.Window;
+
+import javax.swing.JRootPane;
+import javax.swing.RootPaneContainer;
+
 import sun.lwawt.LWWindowPeer;
 
 /**
  * Common layer class between OpenGl and Metal.
  */
 public abstract class CFLayer extends CFRetainedResource {
+    protected final LWWindowPeer peer;
+    private final boolean windowSurfaceDisabled;
     protected SurfaceData surfaceData; // represents intermediate buffer (texture)
-    protected LWWindowPeer peer;
 
-    protected CFLayer(long ptr, boolean disposeOnAppKitThread) {
+    protected CFLayer(long ptr, boolean disposeOnAppKitThread, LWWindowPeer peer) {
         super(ptr, disposeOnAppKitThread);
+        this.peer = peer;
+        this.windowSurfaceDisabled = readWindowSurfaceDisabled(peer);
     }
 
     public abstract SurfaceData replaceSurfaceData(int scale);
@@ -84,5 +92,22 @@ public abstract class CFLayer extends CFRetainedResource {
 
     public Object getDestination() {
         return peer.getTarget();
+    }
+
+    protected final boolean isWindowSurfaceDisabled() {
+        return windowSurfaceDisabled;
+    }
+
+    private static boolean readWindowSurfaceDisabled(LWWindowPeer peer) {
+        if (peer == null) return false;
+        Window target = peer.getTarget();
+        if (target instanceof RootPaneContainer rpc) {
+            JRootPane rootPane = rpc.getRootPane();
+            if (rootPane != null) {
+                Object value = rootPane.getClientProperty(CPlatformWindow.WINDOW_SURFACE_DISABLED);
+                return value != null && Boolean.parseBoolean(value.toString());
+            }
+        }
+        return false;
     }
 }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPlatformWindow.java
@@ -146,6 +146,7 @@ public class CPlatformWindow extends CFRetainedResource implements PlatformWindo
     public static final String WINDOW_TITLE_VISIBLE = "apple.awt.windowTitleVisible";
     public static final String WINDOW_APPEARANCE = "apple.awt.windowAppearance";
     public static final String WINDOW_CORNER_RADIUS = "apple.awt.windowCornerRadius";
+    public static final String WINDOW_SURFACE_DISABLED = "apple.awt.windowSurfaceDisabled";
 
     // This system property is named as jdk.* because it is not specific to AWT
     // and it is also used in JavaFX

--- a/test/jdk/java/awt/Window/WindowSurfaceDisabledTest/WindowSurfaceDisabledTest.java
+++ b/test/jdk/java/awt/Window/WindowSurfaceDisabledTest/WindowSurfaceDisabledTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, JetBrains s.r.o.. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key headful
+ * @summary The apple.awt.windowSurfaceDisabled client property suppresses the
+ *          window's Java2D rendering surface.
+ * @requires (os.family == "mac")
+ * @modules java.desktop/sun.awt
+ *          java.desktop/sun.java2d
+ *          java.desktop/sun.lwawt
+ * @run main WindowSurfaceDisabledTest
+ * @run main/othervm -Dsun.java2d.metal=false WindowSurfaceDisabledTest
+ */
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import sun.awt.AWTAccessor;
+import sun.java2d.NullSurfaceData;
+import sun.java2d.SurfaceData;
+import sun.lwawt.LWWindowPeer;
+
+public class WindowSurfaceDisabledTest {
+
+    private static final String WINDOW_SURFACE_DISABLED = "apple.awt.windowSurfaceDisabled";
+
+    public static void main(String[] args) throws Exception {
+        testPropertyNotSet();
+        testPropertySetBeforeShowing();
+    }
+
+    /**
+     * Without the property the window gets its usual surface. Guards the other
+     * cases against passing for the wrong reason: an empty-bounds window also
+     * reports {@code NullSurfaceData}.
+     */
+    private static void testPropertyNotSet() throws Exception {
+        JFrame frame = showFrame(null);
+        try {
+            check(frame, false, "property not set");
+        } finally {
+            dispose(frame);
+        }
+    }
+
+    /** Set before the window is realized: no Java2D surface is created. */
+    private static void testPropertySetBeforeShowing() throws Exception {
+        JFrame frame = showFrame(Boolean.TRUE);
+        try {
+            check(frame, true, "property set before showing");
+        } finally {
+            dispose(frame);
+        }
+    }
+
+    private static JFrame showFrame(Boolean surfaceDisabled) throws Exception {
+        AtomicReference<JFrame> ref = new AtomicReference<>();
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("WindowSurfaceDisabledTest");
+            if (surfaceDisabled != null) {
+                frame.getRootPane().putClientProperty(WINDOW_SURFACE_DISABLED, surfaceDisabled);
+            }
+            frame.setSize(300, 200);
+            frame.setVisible(true);
+            ref.set(frame);
+        });
+        return ref.get();
+    }
+
+    private static void check(JFrame frame, boolean expectDisabled, String what) {
+        SurfaceData sd = surfaceDataOf(frame);
+        boolean disabled = sd instanceof NullSurfaceData;
+        if (disabled != expectDisabled) {
+            throw new RuntimeException(what + ": expected surface "
+                    + (expectDisabled ? "disabled" : "enabled")
+                    + ", but the peer reports " + sd);
+        }
+    }
+
+    private static SurfaceData surfaceDataOf(JFrame frame) {
+        Object peer = AWTAccessor.getComponentAccessor().getPeer(frame);
+        if (!(peer instanceof LWWindowPeer)) {
+            throw new RuntimeException("Unexpected peer: " + peer);
+        }
+        return ((LWWindowPeer) peer).getSurfaceData();
+    }
+
+    private static void dispose(JFrame frame) throws Exception {
+        SwingUtilities.invokeAndWait(frame::dispose);
+    }
+}


### PR DESCRIPTION
Added a `apple.awt.windowSurfaceDisabled` root pane client property that prevents the allocation of 2-3 window-sized drawables by Java2D on macOS/Metal.

The purpose is to reduce the memory footprint of apps/frameworks, such as Compose for Desktop, which don't draw anything in AWT.

The functionality itself was implemented by me with guidance from Claude Opus 5.
The test was written by Claude and verified (both reading and running) by me. There is pretty much only one way to write it, though (show the window, check the surface), so a human would have produced the same code, I think.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
